### PR TITLE
Allow a Kallisto-specific threads parameter (deterministic output)

### DIFF
--- a/aux/mk/irap_map.mk
+++ b/aux/mk/irap_map.mk
@@ -1040,7 +1040,7 @@ kallisto_index_params?=
 kallisto_map_params?=
 kallisto_map_options?=
 # TODO: use $(max_threads) when supported by kallisto with --pseudobam
-kallisto_map_params+= --threads $(max_threads) --pseudobam $(kallisto_map_options)
+kallisto_map_params+= --threads $(or $(kallisto_threads),$(max_threads)) --pseudobam $(kallisto_map_options)
 
 define kallisto_index_filename=
 $(trans_abspath)_kallisto/kallisto_index.irap

--- a/aux/mk/irap_quant.mk
+++ b/aux/mk/irap_quant.mk
@@ -1004,7 +1004,7 @@ $(kallisto_index): $(trans_abspath)
 # read lenth - 3
 # lib - 5
 define run_kallisto_quant=
- irap_wrapper.sh kallisto kallisto quant $(kallisto_quant_params) -i $(kallisto_index_name) $(if $(4),,--single) $(call kallisto_strand_params,$(5)) -l $(3) -s 1  -t $(max_threads) -o $(1)  $(2)
+irap_wrapper.sh kallisto kallisto quant $(kallisto_quant_params) -i $(kallisto_index_name) $(if $(4),,--single) $(call kallisto_strand_params,$(5)) -l $(3) -s 1  -t $(or $(kallisto_threads),$(max_threads)) -o $(1)  $(2)
 endef
 # 
 

--- a/aux/mk/irap_sc_defs.mk
+++ b/aux/mk/irap_sc_defs.mk
@@ -137,6 +137,7 @@ spikein_fasta?=ERCC
 
 mapper?=none
 quant_method?=kallisto
+kallisto_threads=1
 quant_norm_method?=tpm
 quant_norm_tool?=irap
 qc?=on


### PR DESCRIPTION
Kallisto is non-deterministic in multi-threaded mode (even with the default fixed random seed) due to the way reads are selected for fragment length estimation- see https://groups.google.com/forum/#!topic/kallisto-sleuth-users/xa19AYvFjTw.

This PR adds a Kallisto-specific threads parameter in the single-cell SMART-seq parameters to allow override of THREADS ( -> max_threads) when running Kallisto. 

Since in SC we're often running many small quantification jobs I don't see running in single-threaded mode to be a major performance issue.