### PR TITLE
Kallisto: handle fragment length better

### DIFF
--- a/aux/mk/irap_map.mk
+++ b/aux/mk/irap_map.mk
@@ -1068,7 +1068,7 @@ endef
 # should be used for single cell only
 define run_kallisto_map=
 	$(call tophat_setup_dirs,$(1))
-	irap_wrapper.sh kallisto kallisto quant $(if $(call is_pe_lib,$(1)),,--single -l $($(1)_rs) -s 1)  $(call kallisto_strand_params,$(1))  $(kallisto_map_params) -i $(call kallisto_index_prefix) -o $(call lib2bam_folder,$(1))$(1)/ $(2)   && \
+	irap_wrapper.sh kallisto kallisto quant $(if $(call is_pe_lib,$(1)),,--single -l 200 -s 1)  $(call kallisto_strand_params,$(1))  $(kallisto_map_params) -i $(call kallisto_index_prefix) -o $(call lib2bam_folder,$(1))$(1)/ $(2)   && \
 	$(call do_post_process_trans_bam_cmd,$(call lib2bam_folder,$(1))$(1)/pseudoalignments.bam, $(call lib2bam_folder,$(1))$(1)/$(1).tmp.bam) &&\
 	samtools sort --threads $(max_threads) -m $(SAMTOOLS_SORT_MEM_MT) -T $(call lib2bam_folder,$(1))$(1)/$(1) -o $(call lib2bam_folder,$(1))$(1)/$(1).bam $(call lib2bam_folder,$(1))$(1)/$(1).tmp.bam && \
 	$(call bam_rehead,$(call lib2bam_folder,$(1))$(1)/$(1).bam,$(1)) && \

--- a/aux/mk/irap_map.mk
+++ b/aux/mk/irap_map.mk
@@ -1068,7 +1068,7 @@ endef
 # should be used for single cell only
 define run_kallisto_map=
 	$(call tophat_setup_dirs,$(1))
-	irap_wrapper.sh kallisto kallisto quant $(if $(call is_pe_lib,$(1)),,--single -l 200 -s 1)  $(call kallisto_strand_params,$(1))  $(kallisto_map_params) -i $(call kallisto_index_prefix) -o $(call lib2bam_folder,$(1))$(1)/ $(2)   && \
+	irap_wrapper.sh kallisto kallisto quant $(if $(call is_pe_lib,$(1)),,--single -l 200 -s 200)  $(call kallisto_strand_params,$(1))  $(kallisto_map_params) -i $(call kallisto_index_prefix) -o $(call lib2bam_folder,$(1))$(1)/ $(2)   && \
 	$(call do_post_process_trans_bam_cmd,$(call lib2bam_folder,$(1))$(1)/pseudoalignments.bam, $(call lib2bam_folder,$(1))$(1)/$(1).tmp.bam) &&\
 	samtools sort --threads $(max_threads) -m $(SAMTOOLS_SORT_MEM_MT) -T $(call lib2bam_folder,$(1))$(1)/$(1) -o $(call lib2bam_folder,$(1))$(1)/$(1).bam $(call lib2bam_folder,$(1))$(1)/$(1).tmp.bam && \
 	$(call bam_rehead,$(call lib2bam_folder,$(1))$(1)/$(1).bam,$(1)) && \

--- a/aux/mk/irap_quant.mk
+++ b/aux/mk/irap_quant.mk
@@ -1004,7 +1004,7 @@ $(kallisto_index): $(trans_abspath)
 # read lenth - 3
 # lib - 5
 define run_kallisto_quant=
- irap_wrapper.sh kallisto kallisto quant $(kallisto_quant_params) -i $(kallisto_index_name) $(if $(4),,--single -l 200) $(call kallisto_strand_params,$(5)) -s 1  -t $(max_threads) -o $(1)  $(2)
+ irap_wrapper.sh kallisto kallisto quant $(kallisto_quant_params) -i $(kallisto_index_name) $(if $(4),,--single -l 200 -s 200) $(call kallisto_strand_params,$(5)) -t $(max_threads) -o $(1)  $(2)
 endef
 # 
 

--- a/aux/mk/irap_quant.mk
+++ b/aux/mk/irap_quant.mk
@@ -1004,7 +1004,7 @@ $(kallisto_index): $(trans_abspath)
 # read lenth - 3
 # lib - 5
 define run_kallisto_quant=
- irap_wrapper.sh kallisto kallisto quant $(kallisto_quant_params) -i $(kallisto_index_name) $(if $(4),,--single) $(call kallisto_strand_params,$(5)) -l $(3) -s 1  -t $(max_threads) -o $(1)  $(2)
+ irap_wrapper.sh kallisto kallisto quant $(kallisto_quant_params) -i $(kallisto_index_name) $(if $(4),,--single -l 200) $(call kallisto_strand_params,$(5)) -s 1  -t $(max_threads) -o $(1)  $(2)
 endef
 # 
 


### PR DESCRIPTION
Currently iRAP is specifying read length for the fragment length parameter in Kallisto (-l), in both single- and paired-end read in irap_quant.mk, and for single-end in the other usage in irap_map.mk. 

Read length is unlikely to be a good estimator of fragment length. For paired-end libraries it would be better to allow Kallisto to make its own estimates, while for single-end a fixed typical value of ~200 is probably more sensible than using read length, in the absence of better estimates from experimentalists.