### PR TITLE
Recognise no spikes

### DIFF
--- a/aux/mk/irap_defs.mk
+++ b/aux/mk/irap_defs.mk
@@ -102,7 +102,7 @@ user_trans:=auto
 ## which genes will be included in the cdna file
 user_trans_biotypes:=protein_coding|lincRNA
 ## always include the ercc spikeins
-spikein_fasta:=ERCC
+spikein_fasta?=ERCC
 ##
 
 ## get tsne

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -570,6 +570,8 @@ for (specie in species) {
     ## spikein
     if ( grepl("ercc.*",spikein) ) {
         conf.l <- rbind(conf.l,paste0("spikein_fasta=ERCC"))
+    } else if ( spikein == 'none' ) {
+        conf.l <- rbind(conf.l,paste0("spikein_fasta="))
     } else {
         conf.l <- rbind(conf.l,paste0("#spikein_fasta=",spikein))
     }

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -568,9 +568,13 @@ for (specie in species) {
     conf.l <- rbind(conf.l,paste0("gtf_file=",opt$gtf_file))
     
     ## spikein
+    #
+    # Value will be '' if no column was found, or if the column is empty (in
+    # which case we assert no spikes). 
+
     if ( grepl("ercc.*",spikein) ) {
         conf.l <- rbind(conf.l,paste0("spikein_fasta=ERCC"))
-    } else if ( spikein == 'none' ) {
+    } else if ( spikein == 'none' || spikein == '') {
         conf.l <- rbind(conf.l,paste0("spikein_fasta="))
     } else {
         conf.l <- rbind(conf.l,paste0("#spikein_fasta=",spikein))

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -574,7 +574,7 @@ for (specie in species) {
 
     if ( grepl("ercc.*",spikein) ) {
         conf.l <- rbind(conf.l,paste0("spikein_fasta=ERCC"))
-    } else if ( spikein == 'none' || spikein == '') {
+    } else if ( spikein == 'none' || gsub(' ', '', spikein) == '') {
         conf.l <- rbind(conf.l,paste0("spikein_fasta="))
     } else {
         conf.l <- rbind(conf.l,paste0("#spikein_fasta=",spikein))


### PR DESCRIPTION
This PR allows for spike-ins to be disabled for single-cell data where the .sdrf file specifies 'none' for 'Comment[spike in]'. 

We have examples of Smart-seq2 studies that do not specify spike-in inclusion, and need to be able to quantify without them.

There is pre-existing provision in irap_core.mk to disable spikes where spikein_fasta is set to an empty value. This PR sets that empty value with extra code in irap_sdrf2conf, and prevents it from being overridden by changing the assignment operator in irap_defs.mk.