### PR TITLE
Allow for NAs as empty values in technical replicate column

### DIFF
--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -411,7 +411,7 @@ if ( ! normalize.cols("technical replicate group") %in% colnames(sdrf) ) {
     is.empty <- tr == "" | is.na(tr)
     if (all(is.empty) || length(unique(tr)) == 1){
         sdrf[,nc] <- ""
-    }else if ( any(is.emtpy) ){
+    }else if ( any(is.empty) ){
         perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values where some values are set")
         q(status=1)
     }

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -402,17 +402,19 @@ if ( ! normalize.cols("technical replicate group") %in% colnames(sdrf) ) {
     ## some groups entries may be empty
     ## use the source name to fill the missing values
     nc <- normalize.cols("technical replicate group")
-    is.empty <- sdrf[,nc]==""
-    if ( sum(is.empty)>0) {
-        perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values")
+
+    # Consider that there are no tech rep groups if 1) all values are empty (''
+    # or NA) or 2) there is a single value
+
+    tr <- sdrf[,nc]
+
+    is.empty <- tr == "" | is.na(tr)
+    if (all(is.empty) || length(unique(tr)) == 1){
+        sdrf[,nc] <- ""
+    }else if ( any(is.emtpy) ){
+        perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values where some values are set")
         q(status=1)
     }
-    ## ignore if there is a single value: e.g., not aplicable
-    nn <- table(tolower(sdrf[,nc]))
-    if ( max(nn) == length(nrow(sdrf)) ) {
-        sdrf[,nc] <- ""
-    }
-    #sdrf$"technical replicate group"[is.empty] <- sdrf$"source name"[is.empty]
 }
 
 ######


### PR DESCRIPTION
This PR changes behaviour in the parsing of the technical replicate column in SDRF files to:

- consider NA as empty
- allow the whole column to be empty where technical replicates are absent (rather than populated with 'not applicable' or something)

An error is still returned where only a subset of entries are empty.