### PR TITLE
Prevent irap_sdrf2conf from dropping metadata dimensions

### DIFF
--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -695,7 +695,7 @@ for (specie in species) {
             ofile <- paste0(opt$out_conf,".metadata.tsv")
             to.save <- sdfcols2save2tsv
             if (has.tr) { to.save <- c(to.save,"technical replicate group") }
-            layout2save <- layout[,normalize.cols(to.save)]
+            layout2save <- layout[,normalize.cols(to.save),drop=FALSE]
             layout2save <- cbind(run=rownames(layout2save),layout2save)
             write.tsv(layout2save,file=ofile,header=TRUE)
             pinfo("Created ",ofile)


### PR DESCRIPTION
This PR addresses an issue where dimensions are dropped when a single column is being saved for the metadata file.