### PR TITLE
Deal with the case of a single single-cell SDRF

### DIFF
--- a/scripts/irap_control.sh
+++ b/scripts/irap_control.sh
@@ -101,7 +101,7 @@ mkdir -p $control_folder
 
 
 if [ "$ID-" == "-" ]; then
-    SDRF_FILES=`grep conf .control/*.sdrf.status|cut -f 1 -d:`
+    SDRF_FILES=`grep -H conf .control/*.sdrf.status|cut -f 1 -d:`
     files=( $SDRF_FILES )
     echo "Found ${#files[@]} SDRF files"
 else


### PR DESCRIPTION
This is a trivial PR to deal with the edge case of a single single-cell .sdrf file. The changed line uses grep to identify files with a matching string, and extract the file name from the results. Unfortunately grep does't return this info when grep'ing a single file- unless you add '-H' as applied here.