### PR TITLE
Sc3 column names

### DIFF
--- a/scripts/irap_sc3
+++ b/scripts/irap_sc3
@@ -106,7 +106,7 @@ if (!do.clustering) {
 } else {
   
   # Create SingleCellExperiment
-  # 2018-09-24: SingleCellExperiment does not support sparse matrices :(
+  # 2018-09-24: SC3 does not support sparse matrices :(
   sce <- SingleCellExperiment(
     assays = list(
       counts = as.matrix(raw),

--- a/scripts/irap_sc3
+++ b/scripts/irap_sc3
@@ -154,7 +154,7 @@ if (!do.clustering) {
 
   # Extract cluster columns from results and prepend k-related columns
 
-  clusters_by_k <- data.frame(cbind(data.frame(sel.K = (ks == sel.k), K=ks), t(as.matrix(colData(sce)[,paste0("sc3_",ks,"_clusters")]))))
+  clusters_by_k <- data.frame(cbind(data.frame(sel.K = (ks == sel.k), K=ks), t(as.matrix(colData(sce)[,paste0("sc3_",ks,"_clusters")]))), check.names = FALSE)
 }
 
 if (nrow(clusters_by_k)==0) {


### PR DESCRIPTION
This PR addresses two issues:

* A boo-boo of my own: when re-writing this script when I forgot to turn of check.names, which is necessary to preserve some oddities we encounter.
* Correct Nuno's comment re: sparse matrices. SingleCellExperiment objects can indeed contain sparse matrices (I have examples if required) - but SC3 does choke on them.