### PR TITLE
Increase memory for sdrf_control processes

### DIFF
--- a/scripts/sdrf_control.sh
+++ b/scripts/sdrf_control.sh
@@ -54,7 +54,7 @@ IRAP_AE_SETUP_PARAMS=
 QUEUE=production-rh7
 LSF_GROUP=/download
 EMAIL_CC=
-MEM=8000
+MEM=16384
 
 sdrf_control_conf_file=$TOPLEVEL_FOLDER/sdrf_control.conf
 if [ -e $sdrf_control_conf_file ]; then


### PR DESCRIPTION
This PR increases the memory passed to sub-processes of sdrf_control.sh, which we found to be insufficient.