### PR TITLE
Locate manual download folder at same level as raw data download used…

### DIFF
--- a/scripts/irap_AE_setup.sh
+++ b/scripts/irap_AE_setup.sh
@@ -221,7 +221,7 @@ if [ $N_FQ -gt 5090 ]; then
 fi
 
 ## avoid keeping the local download folder under ROOT_DIR
-local_download_folder=$(readlink -f $ROOT_DIR/../ManuallyDownloaded/$ID)
+local_download_folder=$(readlink -f $DATA_DIR/ManuallyDownloaded/$ID)
 pinfo "previously downloaded data folder=$local_download_folder"
 ###################################
 set -e


### PR DESCRIPTION
… for ENA runs etc

This PR is a last bit of directory shuffling related to https://github.com/nunofonseca/irap/pull/63.