### PR TITLE
Sort before genomecov

### DIFF
--- a/scripts/cram2bw
+++ b/scripts/cram2bw
@@ -30,7 +30,7 @@ echo "Converting to bedgraph/bw..."
 for f in $cram_files; do
     echo -n "$f..."
     # include intron-spanning reads
-    samtools view -b $f | bedtools  genomecov -ibam stdin -bg -g $chr_sizes > $f.bedgraph
+    samtools view -b $f | samtools sort - | bedtools  genomecov -ibam stdin -bg -g $chr_sizes > $f.bedgraph
     bedGraphToBigWig $f.bedgraph $chr_sizes $f.bw
     # rm -f $f.bedgraph
     bw_files="$f.bw $bw_files"


### PR DESCRIPTION
This PR is to deal with sort issues in using genomecov from cram files, like:

```
Input error: Chromosome 6 found in non-sequential lines. This suggests that the input file is not sorted correctly
```