### PR TITLE
Fix to retain Number of reads

### DIFF
--- a/scripts/fastq_info.sh
+++ b/scripts/fastq_info.sh
@@ -5,7 +5,7 @@ if [ "$*-" == "-"  ]; then
     exit 1
 fi
 
-A="`fastq_info $* 2>&1 | tee >(cat 1>&2) |tail -n 5`"  
+A="`fastq_info $* 2>&1 | tee >(cat 1>&2) | sed -n '/Number of reads/,$p'`"  
 ret=$?
 if [ $ret != 0 ]; then
     echo "ERROR" 1>&2


### PR DESCRIPTION
This PR fixes an issue encountered when getting read numbers from the output of fastq_info.sh. For some reason, in the paired-end case the tail -n 5 did not include the read numbers line. The suggested fix here uses sed to explicitly request file content from 'Number of Reads' onwards.