### PR TITLE
Restore coordinate-sorted bam output

### DIFF
--- a/aux/mk/irap_core.mk
+++ b/aux/mk/irap_core.mk
@@ -1888,7 +1888,7 @@ STAGE1_S_TARGETS?=
 
 ifneq ($(mapper),none)
 
-bam_files:=$(foreach p,$(pe), $(call lib2bam_folder,$(p))$(p).pe.hits.byname.bam) $(foreach s,$(se), $(call lib2bam_folder,$(s))$(s).se.hits.bam)
+bam_files:=$(foreach p,$(pe), $(call lib2bam_folder,$(p))$(p).pe.hits.bam) $(foreach s,$(se), $(call lib2bam_folder,$(s))$(s).se.hits.bam)
 STAGE2BYNAME_OUT_FILES:=$(subst .hits.bam,.hits.byname.bam,$(bam_files))
 
 else


### PR DESCRIPTION
For some reason the content of bam_files has been changed in recent iRAP updates, such that paired-end libraries return name-sorted bams from print_bam_filenames(), with single- end returning coordinate-sorted. This causes cram files generated by irap_single_lib to be name-sorted also, causing us problems in track generation.

This PR makes paired-end consistent with single-end, i.e. a coordinate-sorted bam. 