### PR TITLE
Deal with unpredictable index extensions from HISAT2

### DIFF
--- a/aux/mk/irap_map.mk
+++ b/aux/mk/irap_map.mk
@@ -362,7 +362,7 @@ endef
 endif
 
 define run_hisat2_index=
-	irap_map.sh HISAT2  hisat2-build $(hisat2_index_params) $(1) $(1)
+	irap_map.sh HISAT2  hisat2-build $(hisat2_index_params) $(1) $(1) && touch $(1).ht2indexed
 endef
 
 # 1 - GTF
@@ -395,7 +395,7 @@ endef
 
 # same arguments used for *_index
 define hisat2_index_filename=
-$(2).1.ht2
+$(2).ht2indexed
 endef
 
 define hisat2_trans_index_filename=


### PR DESCRIPTION
This PR deals with unpredictable index extensions used by HISAT2. We can't rely on .ht2 or .ht2l extensions being used, so use a reporter 'touch file' instead.

This is a suggested solution to https://github.com/nunofonseca/irap/issues/87.