### PR TITLE
Don't make matrices at top quant level for non-sc data

### DIFF
--- a/aux/mk/irap_quant.mk
+++ b/aux/mk/irap_quant.mk
@@ -1176,7 +1176,9 @@ endef
 
 else
 
+ifeq ($(rnaseq_type),sc)
 STAGE3_S_OFILES+= $(quant_toplevel_folder)/transcripts.raw.$(quant_method).$(expr_ext)
+endif
 
 ifeq ($(gen_riu),y)
 


### PR DESCRIPTION
This PR addresses an issue whereby in the bulk workflow files like 'transcripts.raw.kallisto.tsv' were deposited at 'top level' paths like processing_data/o/oryza_sativa/irap_qc/none/kallisto/. I believe this file and path pertains to alterations made to iRAP for the single-cell case, but was obstructive in the bulk case. The file is not specific to a library, and when multiple iRAP runs are trying to create and remove the file at the same time it induced failures. 

Assuming the above is correct, this PR suggests a fix whereby the path is only requested for single-cell data.