### PR TITLE
Add novel splices to output file lists with HISAT2

### DIFF
--- a/aux/mk/irap_qc_stats.mk
+++ b/aux/mk/irap_qc_stats.mk
@@ -110,6 +110,16 @@ endif
 ifneq ($(mapper),kallisto)
 ifneq ($(mapper),none)
 MAPPING_REPORT_PRE_STATS+=$(foreach s,$(se), $(call lib2bam_folder,$(s))$(s).se.hits.bam.gene.stats  $(call lib2bam_folder,$(s))$(s).se.hits.bam.stats) $(foreach s,$(pe), $(call lib2bam_folder,$(s))$(s).pe.hits.bam.gene.stats $(call lib2bam_folder,$(s))$(s).pe.hits.bam.stats)
+
+# For HISAT2, also return the novel splicing file
+
+ifeq ($(mapper),hisat2)
+MAPPING_REPORT_PRE_STATS+=$(foreach s,$(se), $(call lib2bam_folder,$(s))$(s).se.novel_splicing.tsv) $(foreach s,$(pe), $(call lib2bam_folder,$(s))$(s).pe.novel_splicing.tsv)
+
+%.novel_splicing.tsv: %.hits.bam
+	cp $*.hits.bam.novel_splicing.tsv $@
+
+endif 
 endif
 endif	
 


### PR DESCRIPTION
Currently when iRAP is used to run HISAT2 via irap_single lib the novel splice sites are calculated but not output to the final directory. This PR adds splices to MAPPING_REPORT_PRE_STATS when HISAT2 is the mapper, and gets reported by print_mapping_report_req() for reporting by irap_single_lib.

I've had to work around the usual Make idiosyncracies (single target etc), so I've copied the splicing from the HISAT2 output where it's been implicitly produced. 