### PR TITLE
modified gnu file open in irap_core.mk to shell cat

### DIFF
--- a/aux/mk/irap_core.mk
+++ b/aux/mk/irap_core.mk
@@ -238,7 +238,7 @@ endif
 #************************
 #Version and license info
 pname=IRAP
-version=$(file < $(IRAP_DIR)/version)
+version=$(shell cat $(IRAP_DIR)/version)
 contact=Developed by Nuno Fonseca (authorname (at) acm.org)
 license=This pipeline is distributed  under the terms of the GNU General Public License 3
 


### PR DESCRIPTION
I have modified file open to shell cat in rap_core.mk which is available only in make version 4.2.
Let me know if this is appropriate.