### PR TITLE
Simplify SC preprocessing

### DIFF
--- a/scripts/irap_AE_setup.sh
+++ b/scripts/irap_AE_setup.sh
@@ -217,7 +217,7 @@ function remote_to_local {
 
     fn=$(basename $file)
     
-    if [ $distribute_by_subfolders == 1 ]; then
+    if [ "$distribute_by_subfolders" -eq 1 ]; then
         ## avoid relying on the download path since not all files come from ENA
         dest_dir=$(get_lib_folder $file)
         mkdir -p $dest_dir
@@ -580,17 +580,19 @@ fi
    
 # Now iterate over the files by set, and run irap
 echo "$FASTQ_FILES" | while read -r l; do
-    first_file=echo "$l" | awk '{print $1}'
-    fn=$(remote_to_local $file $distribute_by_subfolders)
-   
+    first_file=$(echo "$l" | awk '{print $1}')
+    fn=$(remote_to_local $first_file $distribute_by_subfolders)
+
+    localFiles=
+    for fqfile in $l; do
+        localFiles="$localFiles $(remote_to_local $fqfile $distribute_by_subfolders)"
+    done
+
     info_file=${fn}.info
     if ( ! -e $info_file );then 
-        pushd $SPECIES/$ID/fastq
-        irap_fastq_info files=$l
-        popd
+        irap_fastq_info files="$localFiles"
     fi
 done
-
 popd 2>/dev/null
 
 extra_params=

--- a/scripts/irap_AE_setup.sh
+++ b/scripts/irap_AE_setup.sh
@@ -498,6 +498,9 @@ pushd $FASTQ_FOLDER >/dev/null
 # Download fastq files
 # by default assumes that data is in ENA
 
+echo
+echo "### FASTQ downloads:"
+
 FTP_DIR_PREF=
 
 ALT_NAME_COL=`get_column $SDRF_FILE_FP "[SUBMITTED_FILE_NAME]" ''`
@@ -505,7 +508,6 @@ ALT_NAME_COL=`get_column $SDRF_FILE_FP "[SUBMITTED_FILE_NAME]" ''`
 FASTQ_COL=
 FASTQ_COL=`get_column $SDRF_FILE_FP "[FASTQ_URI]" ''`
 FASTQ_COL=${FASTQ_COL// /,}
-echo "FASTQ_URI=$FASTQ_COL"
 
 if [ "$FASTQ_COL-" == "-" ]; then
     echo "FASTQ_URI not found...Looking for alternative column"    
@@ -565,6 +567,9 @@ else
     fi
 fi
    
+echo
+echo "### FASTQ FILE checks:"
+
 # Now iterate over the files by set, and run irap
 echo "$FASTQ_FILES" | while read -r l; do
     first_file=$(echo "$l" | awk '{print $1}')

--- a/scripts/irap_AE_setup.sh
+++ b/scripts/irap_AE_setup.sh
@@ -43,6 +43,10 @@ function usage {
 EOF
 }
 
+################################################################################
+# Function definitions
+################################################################################
+
 function pinfo {
     echo "== $*"
 }
@@ -51,8 +55,8 @@ function perror {
     echo "ERROR: $*"  1>&2
 }
 
-## fix the filename by replacing some characters
-## that may complicate things
+## fix the filename by replacing some characters that may complicate things
+
 function fix_filename {
     echo ${1//\#/_};
 }
@@ -60,10 +64,10 @@ function fix_filename {
 function create_dir {
     FOLDER=$1
     if [ ! -e $FOLDER ]; then
-	pinfo creating $FOLDER
-	set -e
-	mkdir -p $FOLDER
-	set +e
+	    pinfo creating $FOLDER
+	    set -e
+	    mkdir -p $FOLDER
+	    set +e
     fi
 }
 
@@ -76,34 +80,141 @@ function get_column {
     COL=$(head -n 1 $sdrf_file | tr "\t" "\n" | grep -i -n -F "$colname" | cut -f 1 -d:)
     set +e
     if [ "$COL-" == "-" ] && [ "$exit_on_error-" != "-" ]; then
-	perror column $colname not found in $sdrf_file
-	exit 1
+	    perror column $colname not found in $sdrf_file
+	    exit 1
     fi
     echo $COL
 }
-####################################
+
 # Look for the species column in the SDRF
+
 function get_species {
     COL=""
     COL=$(get_column $1 "[organism]")
     if [ "$COL-" == "-" ]; then
-	perror organism not found in $1
-	exit 1
+	    perror organism not found in $1
+	    exit 1
     fi
     if [ "$(echo $COL | wc -w)" != "1" ]; then
-	cols="$(echo $COL| tr ' ' ',')"
-	perror found multiple organism columns in $1: $(head -n 1 $1|cut -f $cols)
-	exit 1
+	    cols="$(echo $COL| tr ' ' ',')"
+	    perror found multiple organism columns in $1: $(head -n 1 $1|cut -f $cols)
+	    exit 1
     fi
-#    NSPECIES=$(tail -n +2 $SDRF_FILE|cut -f $COL |sort -u |wc -l)
-#    if [ $NSPECIES -ne 1 ]; then
-#	perror "SDRF files with data from different ($NSPECIES) organisms not supported yet"
-#	exit 1
-    #    fi
     tail -n +2 $1|cut -f $COL |sort -u
 }
 
-###################################
+# TODO: handle the cases where the fastq_uri  may point to non-fastq files
+# (bam/cram) or be empty
+
+function DOWNLOAD_PUBLIC {
+    local url=$1
+    local ofile=$2
+    local download_program=$3
+    rm -f $ofile.tmp
+    if [ "-$download_program" != "-" ]; then
+    	echo "Running: $download_program $url $ofile.tmp"
+	    $download_program $url $ofile.tmp && mv $ofile.tmp $ofile
+    else
+	    wget  -nv -c $url -O $ofile.tmp && mv $ofile.tmp $ofile
+    fi
+    [ -e $ofile ]
+}
+
+function DOWNLOAD_PRIVATE {
+    url=$1
+    ofile=$2
+    id=$3
+    sdrf_file=$4
+    ## submitted file
+    if [ "$ALT_NAME_COL-" != "-" ]; then
+	    set -e
+	    sub_file=`grep "$url" $sdrf_file|cut -f $ALT_NAME_COL`
+	    echo $sub_file
+	    echo `pwd`
+	    chmod 777 .
+	    rm -f $ofile.tmp
+	    set +e
+	    sudo -u fg_cur scp sra-login-2:/fire/staging/aexpress/$id-*/$sub_file $ofile.tmp
+	    sudo -u fg_cur chmod 766 $ofile.tmp
+	    mv $ofile.tmp $ofile
+    fi
+    [ -e $ofile ]
+}
+
+function DOWNLOAD_PRIVATE2 {
+    local url=$1
+    local ofile=$2
+    local id=$3
+    local sdrf_file=$4
+    ## submitted file
+    set +e
+    rm -f $ofile.tmp
+    FOLDER_AT_EBI="/ebi/ftp/pub/databases/microarray/data/experiment/MTAB"
+    file_loc="$FOLDER_AT_EBI/$id/$ofile"
+    if [ -e $file_loc ]; then
+	    echo "File found @ $file_loc"
+	    cp -uva $file_loc $ofile.tmp
+	    mv $ofile.tmp $ofile
+    else
+	    echo "file $file_loc not found"
+    fi
+    [ -e $ofile ]
+}
+
+function download {
+    file=$1
+    fn=$2
+    local download_program=$3
+    ##
+    if [ -e $local_download_folder ] && [ "-$local_download_folder" != "-" ]; then
+        pinfo "Skipping download - looking for $fn in $local_download_folder"
+        if [ -e $local_download_folder/$file ]; then
+            ## rename file if necessary
+            ## note: the subfolder, if used, is based on the $file name
+            fn=$(fix_filename $fn)
+            # avoid duplicating
+            if [ ! -h $(readlink -f $fn) ]; then
+                ln -s $(readlink -f  $local_download_folder/$file) $(readlink -f $fn)
+            fi
+        else
+            perror "File $local_download_folder/$file  not found"
+            exit 1
+        fi
+    else
+        ## 
+        pinfo "downloading $fn"
+        if [ "$dl_fun" == "DOWNLOAD_PUBLIC" ]; then
+            set +e
+            DOWNLOAD_PUBLIC $file $fn $download_program
+            if [ $? -ne 0 ]; then
+                echo "Failed to download from ENA  $file ..."  1>&2
+                dl_fun="DOWNLOAD_PRIVATE"
+            fi
+	        set -e
+	    fi
+	
+        if [ "$dl_fun" == "DOWNLOAD_PRIVATE" ]; then
+            stdbuf -o0 echo -n
+            set +e
+            DOWNLOAD_PRIVATE $file $fn $ID $SDRF_FILE_FP
+            if [ $? -ne 0 ]; then
+                echo "Failed to download from private location $file ..."  1>&2
+                stdbuf -o0 echo -n
+                DOWNLOAD_PRIVATE2 $file $fn $ID $SDRF_FILE_FP
+                if [ $? -ne 0 ]; then
+                    perror "Failed to download from private location2 $file ...given up"
+                    exit 1
+                fi
+            fi
+            set -e		
+        fi
+    fi
+}
+
+################################################################################
+# Parse arguments
+################################################################################
+
 ROOT_DIR=$PWD
 DATA_DIR=$ROOT_DIR/data
 CONF_DIR=$ROOT_DIR/conf/study
@@ -165,7 +276,12 @@ if [ $habemus_batches != 0 ]; then
     pinfo "batch=$batch_number"
     pinfo "batch size=$batch_size"
 fi
-###################################
+
+################################################################################
+# Main script body
+################################################################################
+
+# If ID has been provided and we want to download SDRF and idf
 
 if [ "$DOWNLOAD_SDRF" == "y" ]; then
     pinfo "DOWNLOADING SDRF "
@@ -181,39 +297,43 @@ if [ "$DOWNLOAD_SDRF" == "y" ]; then
     IDF_URL="$SDRF_ROOT_URL/$ID/$IDF_FILE"
     
     if [ $USE_CACHE -eq 1 ]  &&  [ -e $SDRF_FILE_FP ]; then
-	pinfo "skipping downloading $SDRF_FILE"
+	    pinfo "skipping downloading $SDRF_FILE"
     else
-	pinfo "downloading $SDRF_URL"
-	set -e
-	wget  --show-progress -c $SDRF_URL -O $SDRF_FILE_FP
-	set +e
+	    pinfo "downloading $SDRF_URL"
+	    set -e
+	    wget  --show-progress -c $SDRF_URL -O $SDRF_FILE_FP
+	    set +e
     fi
     if [ $USE_CACHE -eq 1 ]  &&  [ -e $IDF_FILE_FP ]; then
-	pinfo "skipping downloading $IDF_FILE"
+	    pinfo "skipping downloading $IDF_FILE"
     else
-	pinfo "downloading $IDF_URL"
-	set -e
-	wget  --show-progress -c $IDF_URL -O $IDF_FILE_FP
-	set +e
+	    pinfo "downloading $IDF_URL"
+    	set -e
+	    wget  --show-progress -c $IDF_URL -O $IDF_FILE_FP
+	    set +e
     fi
+
+# If SDRF has been provided and we want to derive ID and IDF
+
 else
     if [ ! -e $ID ]; then
-	perror "File $ID not found"
-	exit 1
+	    perror "File $ID not found"
+	    exit 1
     fi
     SDRF_FILE=$(basename $ID)
     SDRF_FILE_FP=$(readlink -f $ID)
     ID=$(basename $ID|sed 's/.sdrf.txt.*//')
     IDF_FILE=$(dirname $SDRF_FILE_FP)/$ID.idf.txt
     if [ ! -e $IDF_FILE ]; then
-	perror "File $ID_FILE not found"
-	exit 1
+	    perror "File $ID_FILE not found"
+	    exit 1
     fi
     IDF_FILE_FP=$(readlink -f $IDF_FILE)    
 fi
 
 ## to keep backwards compatibility do not distribute fastq files
 ## if the number of entries/rows in the SDRF is below 5100
+
 distribute_by_subfolders=0
 N_FQ=$(cut -f 1 $SDRF_FILE_FP|wc -l )
 if [ $N_FQ -gt 5090 ]; then
@@ -221,11 +341,13 @@ if [ $N_FQ -gt 5090 ]; then
 fi
 
 ## avoid keeping the local download folder under ROOT_DIR
+
 local_download_folder=$(readlink -f $DATA_DIR/ManuallyDownloaded/$ID)
 pinfo "previously downloaded data folder=$local_download_folder"
-###################################
+
+# Derive some paths
+
 set -e
-#set -ex
 pinfo "id=$ID"
 TOP_FOLDER=$ROOT_DIR/tmp/$ID
 SPECIES_CONF_DIR=$ROOT_DIR/conf/species
@@ -241,14 +363,13 @@ if [ "$SPECIES-" == "-" ]; then
     exit 1
 fi
 
-###################################
-##
 NL=$(wc -l $SDRF_FILE_FP|cut -f 1 -d\ )
 pinfo $SDRF_FILE with $NL lines
-####################################
+
 # batches
+
 if [ $habemus_batches != 0 ]; then
-    ##
+    
     pwd
     cd $ROOT_DIR
     tmp_file_pref=$ROOT_DIR/$SPECIES/$ID/.$(basename $SDRF_FILE_FP)
@@ -256,73 +377,77 @@ if [ $habemus_batches != 0 ]; then
     tmp_file_split=$tmp_file_pref.split.$batch_size
     mkdir -p $ROOT_DIR/$SPECIES/$ID/
     if [ -e $tmp_file_split.1 ] && [ $tmp_file_split.1 -nt $SDRF_FILE_FP ]; then
-	echo "Using cached $tmp_file_split.1 "
+	    echo "Using cached $tmp_file_split.1 "
     else
-	pinfo "Splitting sdrf into $batch_size long chunks"
-	if [ ! -e $tmp_file_lock ]; then
-	    touch $tmp_file_lock
-	    tail -n +2 $SDRF_FILE_FP|cut -f 1 |sort -u > ${tmp_file_pref}.libs
-	    echo "Libs=$(wc -l ${tmp_file_pref}.libs)"
-	    split -a 4 --lines $batch_size  --numeric-suffixes=1  ${tmp_file_pref}.libs $tmp_file_split.
-	    rename split.$batch_size.0 split.$batch_size. $tmp_file_split.0*
-	    rename split.$batch_size.0 split.$batch_size. $tmp_file_split.0*
-	    rename split.$batch_size.0 split.$batch_size. $tmp_file_split.0*
-	    rm -f $tmp_file_lock
-	else
-	    perror "unable to proceed - please delete lock file $tmp_file_lock"
-	    exit
-	fi
+        pinfo "Splitting sdrf into $batch_size long chunks"
+        if [ ! -e $tmp_file_lock ]; then
+            touch $tmp_file_lock
+            tail -n +2 $SDRF_FILE_FP|cut -f 1 |sort -u > ${tmp_file_pref}.libs
+            echo "Libs=$(wc -l ${tmp_file_pref}.libs)"
+            split -a 4 --lines $batch_size  --numeric-suffixes=1  ${tmp_file_pref}.libs $tmp_file_split.
+            rename split.$batch_size.0 split.$batch_size. $tmp_file_split.0*
+            rename split.$batch_size.0 split.$batch_size. $tmp_file_split.0*
+            rename split.$batch_size.0 split.$batch_size. $tmp_file_split.0*
+            rm -f $tmp_file_lock
+        else
+            perror "unable to proceed - please delete lock file $tmp_file_lock"
+            exit
+        fi
     fi
     set -e
+
     if [ "$batch_number-" == "0-" ]; then
-	set +e
-	all_batches=$(shopt -s nullglob && echo $tmp_file_split.*{0,1,2,3,4,5,6,7,8,9}*|sed "s|$tmp_file_split.||g"|tr ' ' '\n' |grep -v .txt|sort -n -u)
-	set -e
-	echo $all_batches
-	for batch_num in $all_batches; do
-	    BCONF_FILE_PREF=$ROOT_DIR/$SPECIES/$ID/$ID.B$batch_num.$batch_size 
-	    BCONF_FILE=$BCONF_FILE_PREF.conf
-	    echo $BCONF_FILE
-	    echo $SDRF_FILE_FP
-	    if [ -e $BCONF_FILE ] && [ $BCONF_FILE -nt $SDRF_FILE_FP ]; then
-		echo Skipping generation of $BCONF_FILE
-	    else
-		set +e
-		let jobs_run=0
-		let jobs_run=$(jobs -r | wc -l)
-		set -e		
-		if [ $jobs_run -gt $THREADS ]; then
-		    echo -n "waiting for slot..."
-		    builtin wait -n
-		    ret=$?
-		    if [ "$ret-" != "0-" ] && [ "$ret-" != "127-" ] ; then
-			perror "Failed to process batch."
-			exit 1
-		    fi
-		    echo "done."
-		fi
-		irap_AE_setup.sh $* -b $batch_num -d $DATA_DIR > $BCONF_FILE.log &
-	    fi
-	done
-	builtin wait
-	if [ "$?-" != "0-" ]; then
-	    perror "Failed to process batch."
-	    exit 1
-	fi
-	# finally...generate a single conf file
-	irap_AE_setup.sh $* -b 0 -B 0 -d $DATA_DIR
-	exit
+
+	    set +e
+	    all_batches=$(shopt -s nullglob && echo $tmp_file_split.*{0,1,2,3,4,5,6,7,8,9}*|sed "s|$tmp_file_split.||g"|tr ' ' '\n' |grep -v .txt|sort -n -u)
+	    set -e
+	    echo $all_batches
+        for batch_num in $all_batches; do
+            BCONF_FILE_PREF=$ROOT_DIR/$SPECIES/$ID/$ID.B$batch_num.$batch_size 
+            BCONF_FILE=$BCONF_FILE_PREF.conf
+            echo $BCONF_FILE
+            echo $SDRF_FILE_FP
+            if [ -e $BCONF_FILE ] && [ $BCONF_FILE -nt $SDRF_FILE_FP ]; then
+                echo Skipping generation of $BCONF_FILE
+            else
+                set +e
+                let jobs_run=0
+                let jobs_run=$(jobs -r | wc -l)
+                set -e		
+                if [ $jobs_run -gt $THREADS ]; then
+                    echo -n "waiting for slot..."
+                    builtin wait -n
+                    ret=$?
+                    if [ "$ret-" != "0-" ] && [ "$ret-" != "127-" ] ; then
+                        perror "Failed to process batch."
+                        exit 1
+                    fi
+                    echo "done."
+                fi
+                irap_AE_setup.sh $* -b $batch_num -d $DATA_DIR > $BCONF_FILE.log &
+            fi
+        done
+        
+        builtin wait
+        if [ "$?-" != "0-" ]; then
+            perror "Failed to process batch."
+            exit 1
+        fi
+        # finally...generate a single conf file
+        irap_AE_setup.sh $* -b 0 -B 0 -d $DATA_DIR
+        exit
     fi
     ## split the sdrf
     splitted_sdrf=$tmp_file_split.$batch_number.sdrf.txt
     if [ -e $splitted_sdrf ] && [ $splitted_sdrf -nt $SDRF_FILE_FP ]; then
-	echo Using cached  $splitted_sdrf
+        echo Using cached  $splitted_sdrf
     else
-	echo "Generating $splitted_sdrf"
-	head -n 1 $SDRF_FILE_FP > $splitted_sdrf.tmp
-	grep -F -w -f $tmp_file_split.$batch_number $SDRF_FILE_FP>> $splitted_sdrf.tmp
-	mv $splitted_sdrf.tmp $splitted_sdrf
+        echo "Generating $splitted_sdrf"
+        head -n 1 $SDRF_FILE_FP > $splitted_sdrf.tmp
+        grep -F -w -f $tmp_file_split.$batch_number $SDRF_FILE_FP>> $splitted_sdrf.tmp
+        mv $splitted_sdrf.tmp $splitted_sdrf
     fi
+
     SDRF_FILE=$splitted_sdrf
     SDRF_FILE_FP=$(readlink -f $splitted_sdrf)
     CONF_FILE_PREF=$TOP_FOLDER/$ID.B$batch_number.$batch_size
@@ -331,38 +456,40 @@ if [ $habemus_batches != 0 ]; then
     pinfo "CONF_FILE=$CONF_FILE"
     pinfo "SDRF_FILE=$SDRF_FILE_FP"
 fi
-####################################
-# IDF
+
+# Use IDF to determine single-cell status and expected cluster number
+
 expected_clusters_params=""
 if [ $skip_idf != "y" ]; then
     pinfo "Processing IDF..."
     set +e
     is_single_cell=$(grep AEExperimentType $IDF_FILE_FP|grep -c "single cells")
     if [ $is_single_cell == 1 ]; then
-	pinfo "single cell RNA-seq"
-	sc_params="--sop atlas_sc --sc"
-	irap_cmd=irap_sc
-	## expected number of clusters
-	if [ $(grep -c EAExpectedClusters $IDF_FILE_FP) -eq 0 ]; then
-	    perror "EAExpectedClusters not found in IDF"
-	    exit 1
-	fi
-	expected_clusters=$(grep EAExpectedClusters $IDF_FILE_FP|cut -f 2)
-	if [ "$expected_clusters-" != "-" ]; then
-	    expected_clusters_params="--nc $expected_clusters"
-	else
-	    expected_clusters_params=""
-	fi
+        pinfo "single cell RNA-seq"
+        sc_params="--sop atlas_sc --sc"
+        irap_cmd=irap_sc
+        ## expected number of clusters
+        if [ $(grep -c EAExpectedClusters $IDF_FILE_FP) -eq 0 ]; then
+            perror "EAExpectedClusters not found in IDF"
+            exit 1
+        fi
+        expected_clusters=$(grep EAExpectedClusters $IDF_FILE_FP|cut -f 2)
+        if [ "$expected_clusters-" != "-" ]; then
+            expected_clusters_params="--nc $expected_clusters"
+        else
+            expected_clusters_params=""
+        fi
     else
-	## assume, by default, that is bulk RNA-seq
-	pinfo "bulk RNA-seq"
-	sc_params=
+        ## assume, by default, that is bulk RNA-seq
+        pinfo "bulk RNA-seq"
+        sc_params=
     fi
     pinfo "Processing IDF...done"
     set -e
 fi
-####################################
-# SDRF
+
+# Check for variables in the SDRF
+
 SOURCE_NAME_COL=$(get_column $SDRF_FILE_FP "SOURCE NAME" 1)
 
 set +e
@@ -372,7 +499,6 @@ pinfo "ENA_SAMPLE_COL: $ENA_SAMPLE_COL"
 
 TECH_REPL_COL=$(get_column $SDRF_FILE_FP "[technical replicate group]")
 pinfo "TECH_REPL_COL: $TECH_REPL_COL"
-
 
 ENA_RUN_COL=$(get_column $SDRF_FILE_FP "[ENA_RUN]")
 pinfo "ENA_RUN_COL: $ENA_RUN_COL"
@@ -391,17 +517,6 @@ pinfo "LIBRARY_LAYOUT_COL: $LAYOUT_COL"
 LAYOUT_COL=$(get_column $SDRF_FILE_FP "[LIBRARY_LAYOUT]" 1)
 pinfo "LIBRARY_LAYOUT_COL: $LAYOUT_COL"
 
-# optional
-# [single cell quality]
-#SC_QUAL_COL=$(get_column $SDRF_FILE_FP "[single cell quality]" 1)
-#pinfo "single cell quality: $SC_QUAL_COL"
-
-# [end bias]
-#END_BIAS_COL=$(get_column $SDRF_FILE_FP "[end bias]" 1)
-#pinfo "END_BIAS_COL: $END_BIAS_COL"
-
-# not_applicable => ignore
-
 #[LIBRARY_STRATEGY]==RNA_SEQ
 LIB_STRATEGY_COL=$(get_column $SDRF_FILE_FP "[LIBRARY_STRATEGY]" 1)
 pinfo "LIBRARY_STRATEGY_COL: $LIB_STRATEGY_COL"
@@ -415,7 +530,6 @@ set -e
 irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params -c --atlas
 set +e
 
-
 # get unique runs
 RUNS=$(cut -f $ENA_RUN_COL $SDRF_FILE_FP|tail -n +2|sort -u)
 
@@ -428,7 +542,7 @@ pushd $FASTQ_FOLDER
 ################################################
 # Download fastq files
 # by default assumes that data is in ENA
-#FTP_URL_PREF=ftp.sra.ebi.ac.uk/vol1/fastq/
+
 FTP_DIR_PREF=
 
 ALT_NAME_COL=`get_column $SDRF_FILE_FP "[SUBMITTED_FILE_NAME]" ''`
@@ -438,13 +552,13 @@ FASTQ_COL=
 FASTQ_COL=`get_column $SDRF_FILE_FP "[FASTQ_URI]" ''`
 FASTQ_COL=${FASTQ_COL// /,}
 echo "FASTQ_URI=$FASTQ_COL"
+
 if [ "$FASTQ_COL-" == "-" ]; then
-    ##Comment[ArrayExpress FTP file]
     echo "FASTQ_URI not found...Looking for alternative column"    
     FASTQ_COL=`get_column $SDRF_FILE_FP '[ArrayExpress FTP file]' ''`
     if [ "$FASTQ_COL-" == "-" ]; then
-	perror "FASTQ_URI and ArrayExpress FTP file columns not found"
-	exit 1
+        perror "FASTQ_URI and ArrayExpress FTP file columns not found"
+        exit 1
     fi
     FASTQ_COL=${FASTQ_COL// /,}
     echo "FASTQ_LOCATION=$FASTQ_COL"
@@ -452,113 +566,6 @@ fi
 
 FASTQ_FILES=$(cut -f $FASTQ_COL $SDRF_FILE_FP | tail -n +2 )
 N_FQ=$(echo $FASTQ_FILES|wc -w)
-
-# TODO: handle the cases where the fastq_uri  may point to non-fastq files (bam/cram) or be empty
-function DOWNLOAD_PUBLIC {
-    local url=$1
-    local ofile=$2
-    local download_program=$3
-    rm -f $ofile.tmp
-    ##echo "<<<<<<<<<<<<<<<<<"
-    ##echo wget  -nv -c $url -O $ofile.tmp
-    if [ "-$download_program" != "-" ]; then
-	echo "Running: $download_program $url $ofile.tmp"
-	$download_program $url $ofile.tmp && mv $ofile.tmp $ofile
-    else
-	wget  -nv -c $url -O $ofile.tmp && mv $ofile.tmp $ofile
-    fi
-    [ -e $ofile ]
-}
-function DOWNLOAD_PRIVATE {
-    url=$1
-    ofile=$2
-    id=$3
-    sdrf_file=$4
-    ## submitted file
-    if [ "$ALT_NAME_COL-" != "-" ]; then
-	set -e
-	sub_file=`grep "$url" $sdrf_file|cut -f $ALT_NAME_COL`
-	echo $sub_file
-	echo `pwd`
-	chmod 777 .
-	rm -f $ofile.tmp
-	set +e
-	sudo -u fg_cur scp sra-login-2:/fire/staging/aexpress/$id-*/$sub_file $ofile.tmp
-	sudo -u fg_cur chmod 766 $ofile.tmp
-	mv $ofile.tmp $ofile
-    fi
-    [ -e $ofile ]
-}
-
-function DOWNLOAD_PRIVATE2 {
-    local url=$1
-    local ofile=$2
-    local id=$3
-    local sdrf_file=$4
-    ## submitted file
-    set +e
-    rm -f $ofile.tmp
-    FOLDER_AT_EBI="/ebi/ftp/pub/databases/microarray/data/experiment/MTAB"
-    file_loc="$FOLDER_AT_EBI/$id/$ofile"
-    if [ -e $file_loc ]; then
-	echo "File found @ $file_loc"
-	cp -uva $file_loc $ofile.tmp
-	mv $ofile.tmp $ofile
-    else
-	echo "file $file_loc not found"
-    fi
-    [ -e $ofile ]
-}
-
-function download {
-    file=$1
-    fn=$2
-    local download_program=$3
-    ##
-    if [ -e $local_download_folder ] && [ "-$local_download_folder" != "-" ]; then
-	pinfo "Skipping download - looking for $fn in $local_download_folder"
-	if [ -e $local_download_folder/$file ]; then
-	    ## rename file if necessary
-	    ## note: the subfolder, if used, is based on the $file name
-	    fn=$(fix_filename $fn)
-	    # avoid duplicating
-	    if [ ! -h $(readlink -f $fn) ]; then
-		ln -s $(readlink -f  $local_download_folder/$file) $(readlink -f $fn)
-	    fi
-	else
-	    perror "File $local_download_folder/$file  not found"
-	    exit 1
-	fi
-    else
-	## 
-	pinfo "downloading $fn"
-	if [ "$dl_fun" == "DOWNLOAD_PUBLIC" ]; then
-	    set +e
-	    DOWNLOAD_PUBLIC $file $fn $download_program
-	    if [ $? -ne 0 ]; then
-	    echo "Failed to download from ENA  $file ..."  1>&2
-	    dl_fun="DOWNLOAD_PRIVATE"
-	fi
-	    set -e
-	fi
-	
-	if [ "$dl_fun" == "DOWNLOAD_PRIVATE" ]; then
-	    stdbuf -o0 echo -n
-	    set +e
-	    DOWNLOAD_PRIVATE $file $fn $ID $SDRF_FILE_FP
-	    if [ $? -ne 0 ]; then
-		echo "Failed to download from private location $file ..."  1>&2
-		stdbuf -o0 echo -n
-		DOWNLOAD_PRIVATE2 $file $fn $ID $SDRF_FILE_FP
-		if [ $? -ne 0 ]; then
-		    perror "Failed to download from private location2 $file ...given up"
-		    exit 1
-		fi
-	    fi
-	    set -e		
-	fi
-    fi
-}
 
 if [ $skip_file_checking == 1 ]; then
     pinfo Skipping downloading and checking $N_FQ fastq files
@@ -568,51 +575,45 @@ else
     pinfo Downloading $N_FQ fastq files
     for file in $FASTQ_FILES; do
 	fn=$(basename $file)
-	if [ $distribute_by_subfolders == 1 ]; then
-	    ## avoid relying on the download path since
-	    ## not all files come from ENA
-	    dest_dir=$(get_lib_folder $file)
-	    mkdir -p $dest_dir
-	fi
-	fn=$dest_dir/$fn
-	if ( ( [ -e $fn ] || [ -h $fn ] ) && [ $USE_CACHE -eq 1 ] ) || ( [ $DEBUG -eq 1 ] ); then
-	pinfo "skipped downloading $fn"
-	else
-	    set +e	
-	    let jobs_run=$(jobs -r | wc -l)
-	    set -e
-	    if [ $jobs_run -ge $THREADS ]; then
-		echo -n "."
-		builtin wait -n
-		ret=$?
-		if [ "$ret-" != "0-" ] && [ "$ret-" != "127-" ] ; then
-		    perror "Failed to download."
-		    exit 1
-		fi
-	    fi
-	    if [ $AT_EBI -eq 1 ]; then
-		echo file exists?
-		echo creating symlink?
-		echo TODO
-	    else
-		download $file $fn $download_program &
-	    fi
-	fi
+        if [ $distribute_by_subfolders == 1 ]; then
+            ## avoid relying on the download path since not all files come from ENA
+            dest_dir=$(get_lib_folder $file)
+            mkdir -p $dest_dir
+        fi
+        fn=$dest_dir/$fn
+        if ( ( [ -e $fn ] || [ -h $fn ] ) && [ $USE_CACHE -eq 1 ] ) || ( [ $DEBUG -eq 1 ] ); then
+            pinfo "skipped downloading $fn"
+        else
+            set +e	
+            let jobs_run=$(jobs -r | wc -l)
+            set -e
+            if [ $jobs_run -ge $THREADS ]; then
+                echo -n "."
+                builtin wait -n
+                ret=$?
+                if [ "$ret-" != "0-" ] && [ "$ret-" != "127-" ] ; then
+                    perror "Failed to download."
+                    exit 1
+                fi
+            fi
+            if [ $AT_EBI -eq 1 ]; then
+                echo file exists?
+                echo creating symlink?
+                echo TODO
+            else
+                download $file $fn $download_program &
+            fi
+        fi
     done
     builtin wait
     if [ "$?-" != "0-" ]; then
-	perror "Failed to download."
-	exit 1
+        perror "Failed to download."
+        exit 1
     fi
-
 fi
-
-
-
    
 popd 2>/dev/null
-## for each species...
-##
+
 extra_params=
 if [ $distribute_by_subfolders == 1 ]; then
     extra_params=--subfolder
@@ -623,16 +624,18 @@ set -e
 irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --out_conf $CONF_FILE_PREF  --species=$SPECIES --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params --sc --atlas $extra_params --atlas
 ## comment reference/gtf lines
 ## add an include to the species.conf file
+
 pinfo "Adding last details to the conf. file"
 sed -i "s/^reference/#reference/;s|^gtf_file.*|include $SPECIES_CONF_DIR/$SPECIES.conf|" $CONF_FILE
-#sed -i "s/^reference/#reference/;s/.*_dir=.*fastq//;s|^gtf_file.*|include $SPECIES_CONF_DIR/$SPECIES.conf|" $CONF_FILE
+
 ## Move to the destination dir
-##
+
 DEST_DIR=$CONF_DIR/$SPECIES/$ID
 mkdir -p $DEST_DIR   
 if [ -e $CONF_FILE_PREF.conf ]; then
     mv $CONF_FILE_PREF.* $DEST_DIR
 fi
+
 echo "Files placed in $DEST_DIR"
 if [ $batch_number == 0 ]; then
     rm -rf $TOP_FOLDER

--- a/scripts/irap_AE_setup.sh
+++ b/scripts/irap_AE_setup.sh
@@ -495,9 +495,15 @@ fi
 
 set +e
 
+# Prepare the sdrf2 conf command
+
+SDRF2CONF_COMMAND="irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --idf $IDF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --species_conf $SPECIES_CONF_DIR/$SPECIES.conf --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params --sc --atlas $extra_params --atlas"
+
 # quickly validate the sdrf before continuing
 set -e
-irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --idf $IDF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --species_conf $SPECIES_CONF_DIR/$SPECIES.conf --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params -c --atlas
+
+$SDRF2CONF_COMMAND --check_only
+#irap_sdrf2conf --check_only --name $ID --sdrf $SDRF_FILE_FP --idf $IDF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --species_conf $SPECIES_CONF_DIR/$SPECIES.conf --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params -c --atlas
 set +e
 
 ################################################
@@ -589,8 +595,10 @@ echo "$FASTQ_FILES" | while read -r l; do
     done
 
     info_file=${fn}.info
-    if ( ! -e $info_file );then 
+    if [ ! -e $info_file ];then
         irap_fastq_info files="$localFiles"
+    else
+        echo "Skipped generation of $info_file"
     fi
 done
 popd 2>/dev/null
@@ -612,7 +620,6 @@ if [ -e $CONF_FILE_PREF.conf ]; then
     mv $CONF_FILE_PREF.* $DEST_DIR
 fi
 
-echo "Files placed in $DEST_DIR"
 if [ $batch_number == 0 ]; then
     rm -rf $TOP_FOLDER
 fi

--- a/scripts/irap_AE_setup.sh
+++ b/scripts/irap_AE_setup.sh
@@ -497,11 +497,8 @@ set +e
 
 # quickly validate the sdrf before continuing
 set -e
-irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params -c --atlas
+irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --idf $IDF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --species_conf $SPECIES_CONF_DIR/$SPECIES.conf --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params -c --atlas
 set +e
-
-# get unique runs
-RUNS=$(cut -f $ENA_RUN_COL $SDRF_FILE_FP|tail -n +2|sort -u)
 
 ################################################
 # create folders
@@ -600,10 +597,10 @@ extra_params=
 if [ $distribute_by_subfolders == 1 ]; then
     extra_params=--subfolder
 fi
-echo irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --out_conf $CONF_FILE_PREF  --species=$SPECIES --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq --sop atlas_sc $sc_params $expected_clusters_params $extra_params --atlas
+echo irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --idf $IDF_FILE_FP --out_conf $CONF_FILE_PREF  --species=$SPECIES --species_conf $SPECIES_CONF_DIR/$SPECIES.conf --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq --sop atlas_sc $sc_params $expected_clusters_params $extra_params --atlas
 
 set -e
-irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --out_conf $CONF_FILE_PREF  --species=$SPECIES --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params --sc --atlas $extra_params --atlas
+irap_sdrf2conf --name $ID --sdrf $SDRF_FILE_FP --idf $IDF_FILE_FP --out_conf $CONF_FILE_PREF --species=$SPECIES --species_conf $SPECIES_CONF_DIR/$SPECIES.conf --data_dir=$DATA_DIR --raw_dir=$SPECIES/$ID/fastq $sc_params $expected_clusters_params --sc --atlas $extra_params --atlas
 
 ## Move to the destination dir
 

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -711,7 +711,7 @@ if (any(! fastq.fields.in.sdrf)){
 
 row.files <- lapply(1:nrow(sdrf), function(row.no){
   req.fields <- row.required.fastq.fields[[row.no]]
-  structure(basename(as.character(sdrf[row.no, req.fields])), names = req.fields)
+  structure(basename(as.character(getSDRFCol(req.fields, sdrf, drop = FALSE)[row.no,])), names = req.fields)
 })
 
 ## Check that the required fields are populated

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -78,11 +78,6 @@ if (opt$is_sc) {
   pinfo("Single cell experiment")
 } 
 
-split.files.by.subfolders <- FALSE
-if ( nrow(sdrf) > 5090 || opt$fastq.splited.by.subfolders) {    
-  split.files.by.subfolders <- TRUE
-}
-
 pdebug.enabled <- opt$debug
 
 ################################################################################
@@ -276,7 +271,7 @@ getRunInfo <- function(run){
 }
 
 ################################################################################
-# First round SDRF field checks: non-conditional 
+# First round SDRF field checks: before we know about field content 
 ################################################################################
 
 # Load the SDRF
@@ -284,6 +279,13 @@ getRunInfo <- function(run){
 pinfo("Loading SDRF ",opt$sdrf_file," ...")
 sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="",fill=TRUE)
 pinfo("Loading SDRF...done.")
+
+# Do we have enough rows that we'll have to split the files? 
+
+split.files.by.subfolders <- FALSE
+if ( nrow(sdrf) > 5090 || opt$fastq.splited.by.subfolders) {    
+  split.files.by.subfolders <- TRUE
+}
 
 ## Factors should not be simultaneously comments, niether should characteristics 
 
@@ -517,7 +519,8 @@ if ( !is.null(opt$idf_file) ) {
 }
 
 ################################################################################
-# Second round SDRF field checks: beyond simple field presence 
+# Further SDRF checks now we know the right fields are there and we can look at
+# the content
 ################################################################################
 
 ## User can specify species, in which case we can discard irrelevant rows

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -840,6 +840,8 @@ for (species in names(sdrf.by.species)){
   ## if:
   ##   1) all values are empty ('' or NA) 
   ##   or 2) there is a single value
+    
+  nruns <- length(unique(getSDRFCol('run', species.sdrf)))
   
   if ( colsInSDRF(techrep.col, species.sdrf) ) {
     tr <- getSDRFCol(techrep.col, species.sdrf)
@@ -850,7 +852,7 @@ for (species in names(sdrf.by.species)){
     if ( (! all(is.empty)) && any(is.empty) ){
       perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values where some values are set")
       q(status=1)
-    }else if(n.techrep.groups == 1 ||  n.techrep.groups == nrow(species.sdrf)){
+    }else if(n.techrep.groups == 1 ||  n.techrep.groups == nruns){
       
       # If the technica replicate field has been set, but the group numbers don't
       # indicate technical replication (i.e. every run has its own group, or
@@ -870,9 +872,8 @@ for (species in names(sdrf.by.species)){
   # replicates when we don't
   
   if ( colsInSDRF('ena_sample', species.sdrf) ) {
-    samples <- length(unique(getSDRFCol('ena_sample', species.sdrf)))
-    runs <- length(unique(getSDRFCol('run', species.sdrf)))
-    has.techrep.from.samples <- sum(samples != runs) > 0
+    nsamples <- length(unique(getSDRFCol('ena_sample', species.sdrf)))
+    has.techrep.from.samples <- nsamples != nruns
     if ( has.techrep.from.samples != properties$has.techrep  ) {
       addWarning(paste("Technical replicate group from", techrep.col, paste0('(',properties$has.techrep,')'), " inconsistent with ena_sample", paste0('(',has.techrep.from.samples,')')))
     }

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -493,7 +493,7 @@ if ( !is.null(opt$idf_file) ) {
     idf.attrs <- idf["additionalattributes",]
     
     # exclude "" and ignore case
-    idf.attrs <- sapply(attrs[attrs!=""],tolower)
+    idf.attrs <- sapply(idf.attrs[idf.attrs!=""],tolower)
     
     # Check for fields absent in the SDRF
     not.present <- (! idf.attrs %in% normalize.cols(colnames(sdrf)))
@@ -770,7 +770,17 @@ if(any(n.paired.run.files != 2)){
 ## Finally, collapse to files per run
 
 run.fastq.files <- lapply(unique(sdrf$run), function(run){
-  unlist(row.files[sdrf$run == run])
+  
+  # If there are multiple rows, then this is paired-end. Sort so that first
+  # read file comes first. Otherwise maintain ordering
+
+  fq.files <- unlist(row.files[sdrf$run == run])
+  
+  if ( length(which(sdrf$run == run)) > 1 ){
+    sort(fq.files)  
+  }else{
+    fq.files
+  }
 })
 names(run.fastq.files) <- unique(sdrf$run)
 
@@ -958,7 +968,10 @@ configs <- lapply(names(sdrf.by.species), function(species){
   
   # Get the combined .info file content of each run
   
+  pinfo("Deriving run information from .info files...")
   run.info <- unlist(lapply(species.layout$run, function(x) getRunInfo(x, species.layout) ))
+  pinfo("Run info retrieval done")  
+
   if (! is.null(run.info)){
     info.conf <- run.info
   }

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -57,6 +57,7 @@ option_list <- list(
     make_option(c("-i", "--idf"), type="character", dest="idf_file", default=NULL, help="IDF file name"),
     make_option(c("--sc"), action="store_true",default=FALSE,dest="is_sc",help="Single cell experiment?. Default is FALSE."),
     make_option(c("-c","--check_only"),action="store_true",dest="check_only",default=FALSE,help="Checks the sdrf/idf but skips the generation of the configuration file."),
+    make_option(c("-v","--verbose"),action="store_true",dest="verbose",default=FALSE,help="Produce verbose output."),
     make_option(c("--atlas"),action="store_true",dest="atlas_mode",default=FALSE,help="Enable more stringent checks for the sdrf/idf files (for ExpressionAtlas)"),
     make_option(c("--debug"),action="store_true",dest="debug",default=FALSE,help="Debug mode"),
     make_option(c("--subfolders"),action="store_true",dest="fastq.splited.by.subfolders",default=FALSE,help="Are the files distributed across subfolders"),
@@ -74,10 +75,6 @@ for ( n in names(opt) ) {
   cat(paste0(n,"=",opt[[n]]))
 }
 
-if (opt$is_sc) {
-  pinfo("Single cell experiment")
-} 
-
 pdebug.enabled <- opt$debug
 
 ################################################################################
@@ -90,14 +87,21 @@ warnings.lst <- c()
 addWarning <- function(...) {
     warnings.lst <- append(warnings.lst,paste0(...))
     assign("warnings.lst",warnings.lst,envir = .GlobalEnv)
-    pwarning(...)
 }
 
 printAllWarnings <- function() {
     n <- length(warnings.lst)
     if ( n > 0 ) return
-    pwarning(n," warnings:")
-    sapply(warnings.lst,pwarning)
+    pinfo('### ', n," warnings. Unique entries:")
+    prints <- sapply(unique(warnings.lst),pwarning)
+}
+
+# Print info only in the verbose case
+
+print.info <- function(...){
+    if (opt$verbose){
+        pinfo(paste(...))
+    }
 }
 
 # Simplify column names
@@ -141,11 +145,13 @@ colsInSDRF <- function(cols, sdrf, comment.cols=FALSE,  characteristic.cols=FALS
     
     if (any(! found) ) {
       missed_cols <- cols[! found]
-        if (exit.on.error) {
-            perror("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
+      missing.error <- paste0("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
+
+      if (exit.on.error) {
+            perror(missing.error)
             q(status=1)
         }
-        addWarning("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
+        addWarning(missing.error)
     }
     return(found)
 }
@@ -214,9 +220,9 @@ is.droplet.protocol <- function(x){
 
 # Get the contents of a .info file for a run, if available
 
-getRunInfo <- function(run){
+getRunInfo <- function(run, layout){
   runfiles <- run.fastq.files[[run]]
-  info.file <- file.path(opt$data_dir, "raw_data", paste0(runfiles[1], ".info"))
+  info.file <- file.path(opt$data_dir, "raw_data", opt$raw_dir, paste0(runfiles[1], ".info"))
   
   if (file.exists(info.file)){
     
@@ -237,8 +243,8 @@ getRunInfo <- function(run){
     # The code needs to be changed if that is not the case.
     
     rr <- system(paste0("cat ",info.file,"|sed -E 's/_L[0-9]+_R[A0-9]+_[0-9]+//'"),intern=TRUE)
-    
-    strand <- layout[run,normalize.cols("library_strand")]
+   
+    strand <- getSDRFCol('library strand', layout, drop = FALSE)[run,]
     
     if ( grepl("(first|second)",strand ) ) {
       
@@ -255,15 +261,19 @@ getRunInfo <- function(run){
     # Add in index
     
     if ( "index1 file" %in% names(runfiles)){
-      rr <- c(rr, paste0("",run,"_index1=", runfiles[['index 1 file']]))
+      rr <- c(rr, paste0("",run,"_index1=", runfiles[['index1 file']]))
     } 
     if ( "index2 file" %in% names(runfiles)){
-      rr <- c(rr, paste0("",run,"_index2=", runfiles[['index 2 file']]))
+      rr <- c(rr, paste0("",run,"_index2=", runfiles[['index2 file']]))
     } 
     
     # Record a technical replicate group
-    
-    conf.l <- rbind(conf.l,paste0("",run,"_sample=", as.numeric(as.factor(sdrf.tmp[,techrep.col]))[sdrf.tmp$run==run]))
+    if ( colsInSDRF(techrep.col, layout) ){
+        techrep.groups <- getSDRFCol(techrep.col, layout, drop = FALSE)
+        tr.numeric.groups <- as.numeric(as.factor(techrep.groups[,1]))
+
+        rr <- c(rr,paste0("",run,"_sample=", tr.numeric.groups[rownames(techrep.groups) == run]))
+    }
     rr
   }else{
     addWarning(paste("Info file", info.file, 'not found'))  
@@ -274,11 +284,15 @@ getRunInfo <- function(run){
 # First round SDRF field checks: before we know about field content 
 ################################################################################
 
+if (opt$is_sc) {
+    print.info("Single cell experiment")
+} 
+
 # Load the SDRF
 
-pinfo("Loading SDRF ",opt$sdrf_file," ...")
+print.info("Loading SDRF ",opt$sdrf_file," ...")
 sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="",fill=TRUE)
-pinfo("Loading SDRF...done.")
+print.info("Loading SDRF...done.")
 
 # Do we have enough rows that we'll have to split the files? 
 
@@ -329,14 +343,14 @@ if( opt$is_sc ) {
   opt.cols <- append(opt.cols,sc.opt.cols)
 }
 
-pinfo("Checking presence of columns...")
+print.info("Checking presence of columns...")
 
 found <- colsInSDRF(expected.cols, sdrf, exit.on.error = TRUE)
 found <- colsInSDRF(expected.characteristic.cols,sdrf,characteristic.cols=TRUE, exit.on.error = TRUE)
 found <- colsInSDRF(expected.comment.cols,sdrf,comment.cols=TRUE, exit.on.error = TRUE)
 found <- colsInSDRF(expected.factor.cols,sdrf,factor.cols=TRUE, exit.on.error = TRUE)
 
-pinfo("Checking the presence of columns... done.")
+print.info("Checking the presence of columns... done.")
 
 # Set some variable names we'll be using a lot
 
@@ -357,19 +371,17 @@ idf <- NULL
 idf.attrs <- idf.factors <- c()
 
 if ( !is.null(opt$idf_file) ) {
-  pinfo("Loading IDF...")
+  print.info("Loading IDF...")
   idf <- read.tsv(opt$idf_file,header=FALSE,comment.char="",fill=TRUE,quote="")
   if (is.null(idf) ) {
     perror("Error while loading IDF file ",opt$idf_file)
     q(status=1)
   }
-  pinfo("Loading IDF...done.")
+  print.info("Loading IDF...done.")
   
   ## exclude blank lines
   
   idf <- idf[idf$V1!="",,drop=FALSE]
-  cat("Columns: ",ncol(idf),"\n")
-  cat("Entries: ",nrow(idf),"\n")
   
   ## SecondaryAccession and SequenceDataURI may be non-unique
   
@@ -377,7 +389,6 @@ if ( !is.null(opt$idf_file) ) {
   
   for (ad in allowed_dups){
     if ( sum(tolower(idf[,1]) == ad) > 1 ) {
-      print(paste0("IDF: Multiple '", ad,"' entries"))
       addWarning("IDF: Multiple '", ad,"' entries")
     }
   }
@@ -411,7 +422,6 @@ if ( !is.null(opt$idf_file) ) {
     perror("SDRF file in IDF (",idf["sdrf file",1],") differs from given sdrf file name ",basename(opt$sdrf_file))
     q(status=1)
   }
-  cat("IDF:",paste(rownames(idf),collapse=","),"\n")    
   
   ##expectedclusters
   ##
@@ -535,7 +545,7 @@ if ( !is.null(opt$species) ) {
   sdrf <- sdrf[sdrf$organism == opt$species, ]
 }
 
-pinfo("Species: ",paste(unique(sdrf$organism)),"\n")
+print.info("Species: ",paste(unique(sdrf$organism)),"\n")
 
 ## SDRF-wide single-cell checks. This can result in filtering out rows, so do it
 ## early. In the process we also work out what fastq files are required
@@ -554,7 +564,7 @@ if ( opt$is_sc ) {
     ## Discard cells from analysis that are low quality
     ## OK, OK filtered or not OK
     
-    pinfo("Discarding ",single.cell.quality.counts["not ok"]," runs/cells")
+    print.info("Discarding ",single.cell.quality.counts["not ok"]," runs/cells")
     sdrf <- sdrf[getSDRFCol(sc.quality.col, sdrf) != 'not ok', ]
   }
   
@@ -587,7 +597,7 @@ if ( opt$is_sc ) {
   # Ignore single-cell identifier for droplet-only experiments
   
   if (all(protocols %in% sc.droplet.protocols) && sc.identifier.col %in% factors) {
-    addWarning("You have supplied 'single cell identifier' for an exlusively droplet-based experiment. This column is meaningless in this context and will be ignored")
+    addWarning("You have supplied 'single cell identifier' for an exclusively droplet-based experiment. This column is meaningless in this context and will be ignored")
     factors <- factors[factors != sc.identifier.col]
     sdrf <- sdrf[, colnames(sdrf) != sc.identifier.col]
   }
@@ -608,10 +618,10 @@ if ( opt$is_sc ) {
   # Drop-seq: read 1 = cell + UMI barcodes, read 2 = cDNA
   
   sc.required.fastq.fields = list(
-    '10xv1' = c('read2 file', 'read1 file'),    
-    '10xv1a' = c('read2 file', 'read1 file', 'index1 file'),         
-    '10xv1i' = c('read2 file', 'read1 file', 'index1 file'),
-    '10xv2' = c('read2 file', 'read1 file'),
+    '10xv1' = c('read1 file', 'read2 file'),    
+    '10xv1a' = c('read1 file', 'read2 file', 'index1 file'),         
+    '10xv1i' = c('read1 file', 'read2 file', 'index1 file'),
+    '10xv2' = c('read1 file', 'read2 file'),
     'drop-seq' = c('read1 file', 'read2 file'), 
     "smart-seq2" = 'fastq uri',
     "smarter" = 'fastq uri',
@@ -757,27 +767,6 @@ run.fastq.files <- lapply(unique(sdrf$run), function(run){
 })
 names(run.fastq.files) <- unique(sdrf$run)
 
-## We're done parseing the SDRF, print some information on its content
-
-pinfo("Printing SDRF summary info")
-cat("Columns: ",ncol(sdrf),"\n")
-cat("Entries: ",nrow(sdrf),"\n")
-pinfo("Columns found in SDRF:")
-cat(paste(colnames(sdrf),collapse=","),"\n")
-
-## print the values
-pinfo("Most frequent values per column...")
-for (col in tolower(c(expected.cols,expected.comment.cols,expected.factor.cols,expected.characteristic.cols)) ) {
-  # ignore spaces
-  col <- normalize.cols(col,FALSE)
-  tt <- table(sdrf[,col])
-  if (length(tt)==nrow(sdrf) ) {
-    pinfo(col,": single value per row")
-  } else {
-    pinfo(col,": ",length(tt)," unique values")
-  }
-}
-
 ################################################################################
 # We'll be making a config per species, and these sub-experiments will then we
 # analysed separately. So checks that with an experimental context (presence of
@@ -813,7 +802,7 @@ for (species in names(sdrf.by.species)){
   ## non-empty values of a single type.
   
   if ( colsInSDRF('spike_in', species.sdrf) ) {
-    pinfo("Found 'spike in' column")
+    print.info("Found 'spike in' column")
     spikein <- unique(getSDRFCol('spike_in', species.sdrf))
     if ( length(spikein) > 1 ) {
       perror("SDRF error: Expected one or no spike ins (found ",length(spikein),").")
@@ -861,8 +850,7 @@ for (species in names(sdrf.by.species)){
     runs <- length(unique(getSDRFCol('run', species.sdrf)))
     has.techrep.from.samples <- sum(samples != runs) > 0
     if ( has.techrep.from.samples != properties$has.techrep  ) {
-      pinfo("Technical replicates: SDRF column ", techrep.col, ' ', properties$has.techrep," vs ena_sample ", has.techrep.from.samples)
-      addWarning("Technical replicate group inconsistent with ena_sample")
+      addWarning(paste("Technical replicate group from", techrep.col, paste0('(',properties$has.techrep,')'), " inconsistent with ena_sample", paste0('(',has.techrep.from.samples,')')))
     }
   }
   
@@ -944,7 +932,7 @@ configs <- lapply(names(sdrf.by.species), function(species){
     # Guess at a central K when not provided
     
     if ( opt$nc < 2 ) {
-      opt$nc <- round(log2(nrow(layout)))
+      opt$nc <- round(log2(nrow(species.layout)))
     }
     
     num.min.c <- max(round(opt$nc - opt$nc_window/2,0),2)
@@ -961,7 +949,7 @@ configs <- lapply(names(sdrf.by.species), function(species){
   
   # Get the combined .info file content of each run
   
-  run.info <- unlist(lapply(species.layout$run, getRunInfo ))
+  run.info <- unlist(lapply(species.layout$run, function(x) getRunInfo(x, species.layout) ))
   if (! is.null(run.info)){
     info.conf <- run.info
   }
@@ -991,7 +979,7 @@ configs <- lapply(names(sdrf.by.species), function(species){
   metadata <- NULL
   
   sdfcols2save2tsv <- unique(c(
-    factor.cols,
+    factors,
     idf.factors,
     idf.attrs,
     techrep.col
@@ -1008,12 +996,44 @@ configs <- lapply(names(sdrf.by.species), function(species){
 names(configs) <- names(sdrf.by.species)
 
 
-if ( length(confs)==0 ) {
+if ( length(configs)==0 ) {
   perror("Unable to create configuration file, see above errors")
   q(status=1)
 }
 
 ## Write final outputs
+
+cat("\n\n")
+pinfo('### SDRF checks are done. Summary and warning printed below')
+cat("\n")
+
+## We're done parseing the SDRF, print some information on its content
+
+cat("\n")
+pinfo("### Printing SDRF summary info")
+cat("Columns: ",ncol(sdrf),"\n")
+cat("Entries: ",nrow(sdrf),"\n")
+pinfo("Columns found in SDRF:")
+cat(paste(colnames(sdrf),collapse=","),"\n")
+
+## print the values
+pinfo("Most frequent values per column...")
+for (col in tolower(c(expected.cols,expected.comment.cols,expected.factor.cols,expected.characteristic.cols)) ) {
+  # ignore spaces
+  col <- normalize.cols(col,FALSE)
+  tt <- table(sdrf[,col])
+  if (length(tt)==nrow(sdrf) ) {
+    pinfo(col,": single value per row")
+  } else {
+    pinfo(col,": ",length(tt)," unique values")
+  }
+}
+
+cat("\n")
+printAllWarnings()
+
+cat("\n")
+pinfo("### Outputs:")
 
 for (species in names(configs)){
   
@@ -1042,6 +1062,6 @@ for (species in names(configs)){
   pinfo("Created ", conf.file)
 }
 
-printAllWarnings()
+cat("\n")
 pinfo("All done")
 q(status=0)

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -20,7 +20,10 @@
 #
 # =========================================================
 
-###############################################################
+################################################################################
+# Initialisation
+################################################################################
+
 suppressPackageStartupMessages(library("optparse"))
 
 IRAP.DIR <- Sys.getenv(c("IRAP_DIR"))
@@ -34,7 +37,9 @@ if ( IRAP.DIR == "" ) {
 source(paste(IRAP.DIR,"aux/R","irap_utils.R",sep="/"))
 pdebug.enabled <- TRUE
 
-#######################
+################################################################################
+# Argument parsing
+################################################################################
 
 usage <- "irap_sdrf2conf --name exp_name --species species --sdrf file --out_conf  [options]"
 filenames <- c("sdrf_file","idf_file")
@@ -42,13 +47,12 @@ filenames <- c("sdrf_file","idf_file")
 option_list <- list(
     make_option(c("-n", "--name"), type="character", dest="name", default=NULL, help="(short) name of the experiment (no spaces)"),
     make_option(c("--species"), type="character", dest="species", default=NULL, help="Species name."),
+    make_option(c("--species_conf"), type="character", dest="species_conf", default=NULL, help="iRAP species config file."),
     make_option(c("--data_dir"), type="character", dest="data_dir", default=".", help="iRAP's toplevel data directory"),
     make_option(c("--raw_dir"), type="character", dest="raw_dir", default=".", help="fastq directory"),
     make_option(c("--sop"), type="character", dest="sop", default=NULL, help="iRAP's toplevel data directory"),
     make_option(c("--nc"), type="numeric", dest="nc", default=0, help="estimated number of clusters [default %default]"),
-    make_option(c("--nc_window"), type="numeric", dest="nc_window", default=10, help="Clusters window [default %default]"),    
-    make_option(c("--reference"), type="character", dest="reference", default="$SPECIES_REFERENCE", help="genome reference"),
-    make_option(c("--gtf"), type="character", dest="gtf", default="$SPECIES_GTF", help="gtf"),
+    make_option(c("--nc_window"), type="numeric", dest="nc_window", default=10, help="Clusters window [default %default]"),  
     make_option(c("-s", "--sdrf"), type="character", dest="sdrf_file", default=NULL, help="SDRF file name"),
     make_option(c("-i", "--idf"), type="character", dest="idf_file", default=NULL, help="IDF file name"),
     make_option(c("--sc"), action="store_true",default=FALSE,dest="is_sc",help="Single cell experiment?. Default is FALSE."),
@@ -59,11 +63,25 @@ option_list <- list(
   make_option(c("-o", "--out_conf"), type="character",default=NULL,help="Filename of the new iRAP's configuration file.")
 )
 
-
 multiple.options = list()
-mandatory <- c("sdrf_file","out_conf","name","species")
+mandatory <- c("sdrf_file","out_conf","name","species", "species_conf", "idf_file")
 
-opt <- myParseArgs(usage = usage, option_list=option_list,filenames.exist=filenames,multiple.options=multiple.options,mandatory=mandatory)
+opt <- myParseArgs(usage = usage, option_list=option_list,filenames.exist=filenames,multiple.options=list(),mandatory=mandatory)
+
+# Do some introspection on arguments
+
+for ( n in names(opt) ) {
+  cat(paste0(n,"=",opt[[n]]))
+}
+
+if (opt$is_sc) {
+  pinfo("Single cell experiment")
+} 
+
+split.files.by.subfolders <- FALSE
+if ( nrow(sdrf) > 5090 || opt$fastq.splited.by.subfolders) {    
+  split.files.by.subfolders <- TRUE
+}
 
 pdebug.enabled <- opt$debug
 
@@ -71,59 +89,7 @@ pdebug.enabled <- opt$debug
 # Function definitions
 ################################################################################
 
-checkFiles <- function(filenames.v,validator.cmd="irap_fastq_info",subfolders=FALSE,opt) {
-    ## filenames.v - as provided in the SDRF
-
-    addLibSubfolder <- function(f) {
-        paste0(system(paste0("get_lib_folder ",f),intern=TRUE),"/",f)
-    }
-    fixFilename <- function(f) {
-        paste0(dirname(f),"/",gsub("#","_",basename(f)))
-    }
-    if (subfolders) {
-        filenames.v <- sapply(filenames.v,addLibSubfolder)
-    }
-    filenames.v <- sapply(filenames.v,fixFilename)
-    exp.files <- filenames.v
-    dir <- paste0(opt$data_dir,"/raw_data")
-    exp.files.ps <- paste(exp.files,collapse=" ",sep="")
-
-    stopifnot(validator.cmd %in% c("fastq_info","irap_fastq_info"))
-    stopifnot(length(filenames.v)>0 && length(filenames.v)<=2)
-    use.cached <- FALSE
-    info.file <- paste0(dir,"/",opt$raw_dir,"/",exp.files[1],".info")
-    
-    if (validator.cmd=="fastq_info" ) {
-        ## check if file exists before running fastq_info again
-        if ( file.exists(info.file) ) {
-            pinfo("Using cached info file")
-        } else {
-            cmd <- paste0("cd ",opt$raw_dir," && fastq_info -s -r ",exp.files.ps," > ",exp.files[1],".info.tmp 2> /dev/null && mv ",exp.files[1],".info.tmp ",exp.files[1],".info")
-            cmd.err <- paste0("cd ",opt$raw_dir," && fastq_info ",exp.files.ps," > ",exp.files[1],".info.tmp && mv ",exp.files[1],".info.tmp ",exp.files[1],".info")
-        }
-    } else {
-        cmd <- paste0("cd ",opt$raw_dir," && irap_fastq_info files='",exp.files.ps,"'")
-        cmd.err <- cmd
-    }
-
-    if ( file.exists(info.file) ) {
-        pinfo("Using cached file ",info.file)
-    } else {
-        cmd <- paste0("cd ",dir," && ",cmd)
-        pinfo("Checking ",exp.files.ps)
-        rr <- system(paste0(cmd),intern=FALSE,ignore.stdout=TRUE)
-        
-        if ( ! file.exists(info.file) || rr!=0 ) {
-            print(cmd)
-            ## rerun command to report the error
-            rr <- system(paste0("pushd ",dir," && ",cmd.err),intern=FALSE,ignore.stdout=TRUE,ignore.stderr=FALSE)        
-            perror("Failed to validate and generate info file ",info.file)
-            q(status=1)
-        }
-    }
-    pinfo("ok")
-    return(info.file)    
-}
+# Record warnings as we run checks
 
 warnings.lst <- c()
 addWarning <- function(...) {
@@ -131,12 +97,16 @@ addWarning <- function(...) {
     assign("warnings.lst",warnings.lst,envir = .GlobalEnv)
     pwarning(...)
 }
+
 printAllWarnings <- function() {
     n <- length(warnings.lst)
     if ( n > 0 ) return
     pwarning(n," warnings:")
     sapply(warnings.lst,pwarning)
 }
+
+# Simplify column names
+
 normalize.cols <- function(vals,strip.brackets=TRUE) {
     ## try to workaround typos & inconsistencies
     x <- vals
@@ -151,8 +121,12 @@ normalize.cols <- function(vals,strip.brackets=TRUE) {
     return(tolower(gsub(" +"," ",x))) ##lowercase and single space
 }
 
-colsInSDRF <- function(cols,sdrf,comment.cols=FALSE,characteristic.cols=FALSE,factor.cols=FALSE,exit.on.error=TRUE) {
-    if ( length(cols) == 0 ) return
+# Check for SDRF column presence
+
+colsInSDRF <- function(cols, sdrf, comment.cols=FALSE,  characteristic.cols=FALSE, factor.cols=FALSE, exit.on.error = FALSE) {
+
+    if ( length(cols) == 0 ) return()
+
     sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=FALSE)
     to.check.cols <- normalize.cols(cols,strip.brackets=FALSE)
     if (comment.cols) {
@@ -168,709 +142,903 @@ colsInSDRF <- function(cols,sdrf,comment.cols=FALSE,characteristic.cols=FALSE,fa
         sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=TRUE)
         to.check.cols <- normalize.cols(cols,strip.brackets=TRUE)
     }
-    miss <- cols[!to.check.cols%in%sdrf.cols]
-    if (length(miss)>0 ) {
+    found <- to.check.cols %in% sdrf.cols
+    
+    if (any(! found) ) {
+      missed_cols <- cols[! found]
         if (exit.on.error) {
-            perror("SDRF: Column(s) ", paste(miss,collapse=","), " not found")
+            perror("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
             q(status=1)
         }
-        addWarning("SDRF: Column(s) ", paste(miss,collapse=","), " not found")
-        return(miss)
+        addWarning("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
     }
+    return(found)
+}
+
+# Get an SDRF column, normalising the supplied field name
+
+getSDRFCol <- function(cols, sdrf, order.by = NULL, drop = TRUE){
+  sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=FALSE)
+  to.check.cols <- normalize.cols(cols,strip.brackets=FALSE)
+  
+  result <- sdrf[,to.check.cols[to.check.cols %in% sdrf.cols], drop = FALSE]
+  
+  if ( ! is.null(order.by)){
+    result <- result[order(result[,normalize.cols(colnames(result)) == normalize.cols(order.by)]),, drop = FALSE]
+  }
+  
+  if (drop && ncol(result) == 1){
+    result[,1]
+  }else{
+    result
+  }
+}
+
+# Set an SDRF column, normalising the supplied field name
+
+setSDRFCol <- function(cols, sdrf, vals){
+  sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=FALSE)
+  to.check.cols <- normalize.cols(cols,strip.brackets=FALSE)
+  
+  sdrf[,to.check.cols[to.check.cols %in% sdrf.cols]] <- vals
+  sdrf
+}
+
+# Check that a value is filled
+
+populated <- function(y){
+  unlist(lapply(y, function(x){
+    x != '' & x != -1 & gsub(' ', '', x) != '' & ! is.na(x)
+  }))
+}
+
+# Check files exist
+
+fastqFileExists <- function(filenames, topdir, subfolders = F){
+  
+  addLibSubfolder <- function(f) {
+    paste0(system(paste0("get_lib_folder ",f),intern=TRUE),"/",f)
+  }
+  
+  fixFilename <- function(f) {
+    paste0(dirname(f),"/",gsub("#","_",basename(f)))
+  }
+  
+  if (subfolders) {
+    filenames <- sapply(filenames,addLibSubfolder)
+  }
+  
+  file.exists(sapply(file.path(topdir, filenames), fixFilename))
+}
+
+# Check if a method is a droplet protocol
+
+is.droplet.protocol <- function(x){
+  opt$is_sc && tolower(x) %in% tolower(sc.droplet.protocols)
+}
+
+# Get the contents of a .info file for a run, if available
+
+getRunInfo <- function(run){
+  runfiles <- run.fastq.files[[run]]
+  info.file <- file.path(opt$data_dir, "raw_data", paste0(runfiles[1], ".info"))
+  
+  if (file.exists(info.file)){
+    
+    # Read in the content of the info file
+    rr <- readLines(info.file)
+    
+    # Info file content has variable prefixes derived from file names
+    # which are not always the same as the run name. So we need to rename
+    # the variables
+    
+    # Use the _rs field to determine the file prefix, and use that to rename the other variables
+    
+    info.prefix = sub('(.*)_rs.*', '\\1', grep('_rs=', rr, value = TRUE))
+    rr <- sub(info.prefix, run, rr)
+    
+    # Read from the info files. Note/warning: there is an assumption that
+    # the lib name (file basename prefix)  corresponds to the run name.
+    # The code needs to be changed if that is not the case.
+    
+    rr <- system(paste0("cat ",info.file,"|sed -E 's/_L[0-9]+_R[A0-9]+_[0-9]+//'"),intern=TRUE)
+    
+    strand <- layout[run,normalize.cols("library_strand")]
+    
+    if ( grepl("(first|second)",strand ) ) {
+      
+      # If SDRF has a strand definition for this run, discard the one from the info file
+      
+      rr <- rr[grep('strand', rr, invert = TRUE)]
+      if ( grepl("first",strand ) ){
+        rr <- c(rr ,paste0("",run,"_strand=first"))
+      } else {
+        rr <- c(rr,paste0("",run,"_strand=second"))
+      }
+    }
+    
+    # Add in index
+    
+    if ( "index1 file" %in% names(runfiles)){
+      rr <- c(rr, paste0("",run,"_index1=", runfiles[['index 1 file']]))
+    } 
+    if ( "index2 file" %in% names(runfiles)){
+      rr <- c(rr, paste0("",run,"_index2=", runfiles[['index 2 file']]))
+    } 
+    
+    # Record a technical replicate group
+    
+    conf.l <- rbind(conf.l,paste0("",run,"_sample=", as.numeric(as.factor(sdrf.tmp[,techrep.col]))[sdrf.tmp$run==run]))
+    rr
+  }else{
+    addWarning(paste("Info file", info.file, 'not found'))  
+  }
 }
 
 ################################################################################
-# Main script body
+# First round SDRF field checks: non-conditional 
 ################################################################################
 
-pdebug.save.state("irap_sdrf2conf","p0")
-sdfcols2save2tsv <- c()
-
-for ( n in names(opt) ) {
-    cat(paste0(n,"=",opt[[n]]))
-}
+# Load the SDRF
 
 pinfo("Loading SDRF ",opt$sdrf_file," ...")
-sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="")
+sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="",fill=TRUE)
 pinfo("Loading SDRF...done.")
+
+## Factors should not be simultaneously comments, niether should characteristics 
+
+factors <- normalize.cols(colnames(sdrf)[grepl("^factor ?value",colnames(sdrf),ignore.case=TRUE)])
+comments <- normalize.cols(colnames(sdrf)[grepl("^comment",colnames(sdrf),ignore.case=TRUE)])
+characteristics <- normalize.cols(colnames(sdrf)[grepl("^characteristics",colnames(sdrf),ignore.case=TRUE)])
+
+compare <- list( factors = factors, characteristics = characteristics  )
+for (comp in names(compare)){
+  common <- intersect( compare[[comp]], comments )
+  if (length(common)>0) {
+    err_msg <- paste0("SDRF: common ", comp," and comments - ",paste(common,collapse=","))
+    if ( opt$atlas_mode==TRUE ) {
+      perror(err_msg)
+      q(status=1)
+    }
+    addWarning(err_msg)
+  }
+}
+
+## Verify presence of mandatory columns (SDRF) and regularise names
+
+expected.cols <- c("Source Name")
+expected.comment.cols <- c("LIBRARY_STRATEGY","LIBRARY_SOURCE","LIBRARY_SELECTION","LIBRARY_LAYOUT","FASTQ_URI")
+expected.characteristic.cols <- c()
+expected.factor.cols <- c()
+opt.cols <- c("ORGANISM","organism part","sex","spike in","molecule","technical replicate group","ENA_RUN","ENA_SAMPLE","Scan Name")
+layout.cols <- c("run", "library_layout", "ena_sample", "library_layout", "library_strand", "technical replicate group")
+
+# Single-cell specific.
+
+if( opt$is_sc ) {
+  
+  sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file", "index2 file","index3 file")
+  
+  supported.single.cell.protocols <- c("smart-seq2","smarter","smart-like","10xv2","10xv1","drop-seq","10xv1a")
+  sc.droplet.protocols <- c('10xv1', '10xv1a', '10xv1i', '10xv2', 'drop-seq')
+  
+  expected.cols <- append(expected.cols, c("Material Type","library_construction","single cell isolation"))
+  expected.comment.cols <- append(expected.comment.cols, c("LIBRARY_STRAND"))
+  opt.cols <- append(opt.cols,sc.opt.cols)
+}
+
+pinfo("Checking presence of columns...")
+
+found <- colsInSDRF(expected.cols, sdrf, exit.on.error = TRUE)
+found <- colsInSDRF(expected.characteristic.cols,sdrf,characteristic.cols=TRUE, exit.on.error = TRUE)
+found <- colsInSDRF(expected.comment.cols,sdrf,comment.cols=TRUE, exit.on.error = TRUE)
+found <- colsInSDRF(expected.factor.cols,sdrf,factor.cols=TRUE, exit.on.error = TRUE)
+
+pinfo("Checking the presence of columns... done.")
+
+# Set some variable names we'll be using a lot
+
+techrep.col <- 'technical replicate group'
+sc.identifier.col <- 'single cell identifier'
+sc.protocol.col <- 'library construction'
+
+# Now we've checked comments etc we can forget what sort of field these are and
+# regularise the column names
+
+colnames(sdrf) <- normalize.cols(tolower(colnames(sdrf)))
+
+################################################################################
+# Load and check the IDF where provided, and cross-reference with the SDRF
+################################################################################
+
+idf <- NULL
+idf.attrs <- idf.factors <- c()
+
+if ( !is.null(opt$idf_file) ) {
+  pinfo("Loading IDF...")
+  idf <- read.tsv(opt$idf_file,header=FALSE,comment.char="",fill=TRUE,quote="")
+  if (is.null(idf) ) {
+    perror("Error while loading IDF file ",opt$idf_file)
+    q(status=1)
+  }
+  pinfo("Loading IDF...done.")
+  
+  ## exclude blank lines
+  
+  idf <- idf[idf$V1!="",,drop=FALSE]
+  cat("Columns: ",ncol(idf),"\n")
+  cat("Entries: ",nrow(idf),"\n")
+  
+  ## SecondaryAccession and SequenceDataURI may be non-unique
+  
+  allowed_dups <- c('comment[sequencedatauri]', 'comment[secondaryaccession]')
+  
+  for (ad in allowed_dups){
+    if ( sum(tolower(idf[,1]) == ad) > 1 ) {
+      print(paste0("IDF: Multiple '", ad,"' entries"))
+      addWarning("IDF: Multiple '", ad,"' entries")
+    }
+  }
+  
+  idf <- subset(idf, ! tolower(V1) %in% allowed_dups)
+  
+  ## basic idf check (non unique rownames). Some duplicate fields allowed.
+  
+  dups <- unique(idf[duplicated(idf[,1]), 1])
+  
+  if ( length(dups) > 0 ) {
+    dupss <- paste(dups, sep=",", collapse=",")
+    perror("Duplicated entries: ", dupss)
+    q(status=1)
+  }
+  
+  ## error handling should be improved...
+  rownames(idf) <- tolower(gsub("\\s*\\]\\s*","",gsub("^\\s*COMMENT\\s*\\[\\s*","",as.character(idf[,1]),ignore.case=TRUE)))
+  idf <- idf[,-1,drop=FALSE]
+  
+  ## be tolerant about the EA comments
+  rownames(idf) <- gsub("^ea","",rownames(idf))
+  
+  ## initial check
+  if (! "sdrf file" %in% rownames(idf) ) {
+    perror("SDRF file missing from IDF file")
+    q(status=1)
+  }
+  
+  if ( idf["sdrf file",1]!=basename(opt$sdrf_file) ) {      
+    perror("SDRF file in IDF (",idf["sdrf file",1],") differs from given sdrf file name ",basename(opt$sdrf_file))
+    q(status=1)
+  }
+  cat("IDF:",paste(rownames(idf),collapse=","),"\n")    
+  
+  ##expectedclusters
+  ##
+  ## ExperimentType       differential|baseline (mandatory)
+  ## ExpectedClusters     may be empty
+  ## AdditionalAttributes - characteristics (optional) exist in the SDRF
+  ## AEExperimentType RNA-seq of coding RNA from single cells (single cell)
+  ## Protocol Name should match SDRF
+  ## Experimental Factor Name (mandatory) exist in the SDRF
+  ## note: factors and characteristics should always be lower case!! @Laura
+  
+  expected.in.idf <- c()
+  
+  # Required fields for single-cell
+  
+  if ( opt$is_sc ) {
+    expected.in.idf <- c("expectedclusters")
+    names(expected.in.idf) <- c("EAExpectedClusters")
+  }
+  
+  # Required fields for Atlas
+  
+  if ( opt$atlas_mode ) {
+    expected.in.idf2 <- c("experimenttype","experimental factor name","protocol name")
+    names(expected.in.idf2) <- c("AEExperimentType","Experimental Factor Name","Protocol Name")
+    expected.in.idf <- c(expected.in.idf,expected.in.idf2)
+  }
+  
+  # Error where required IDF fields not present
+  
+  not.present <- (!expected.in.idf %in% rownames(idf))
+  if ( sum(not.present)>0 ) {
+    perror("IDF incomplete. Missing ",paste(names(expected.in.idf)[not.present],sep=",",collapse=","))
+    q(status=1)
+  }
+  
+  # Additional IDF checks for Atlas
+  
+  if ( opt$atlas_mode ) {
+    
+    if ( ! tolower(idf["experimenttype",1]) %in% c("baseline","differential") ){
+      perror("IDF error in EAExperimentType: Invalid value (",idf["experimenttype",1],") expected baseline or differential")
+      q(status=1)
+    }
+    
+    ## Check the experiment type
+    
+    exp.type <- tolower(idf["aeexperimenttype",1])
+    valid.exp.types = c( single_cell = "RNA-seq of coding RNA from single cells", bulk = "RNA-seq of coding RNA" )
+    
+    if ( ! exp.type %in% tolower(valid.exp.types) ){
+      perror("IDF error in AEExperimentType: Invalid value (", exp.type,") expected ",paste(valid.exp.types, sep=" or ", collapse=" or "))
+      q(status=1)
+    }
+    
+    # Override argument if we find single-cell experiment type
+    
+    opt$is_sc <- names(valid.exp.types)[tolower(valid.exp.types) == exp.type] == 'single_cell'
+    
+    ## - Experimental Factor Name (mandatory) exist in the SDRF
+    
+    idf.factors <- idf["experimental factor name",][idf["experimental factor name",] != '']
+    
+    ## all factors should be in lower case
+    if ( any(idf.factors != tolower(idf.factors)) ) {
+      perror("IDF error in  Experimental Factor Name: values should be in lower case")
+      q(status)
+    }
+    
+    ## and match the sdrf. Ignore single cell identifier when validating against SDRF- it's not a real factor 
+    
+    if (any(sort(setdiff(idf.factors, sc.identifier.col)) != sort(setdiff(factors, sc.identifier.col)))){
+      perror("SDRF/IDF inconsistency: factor values do not match")
+      q(status=1)
+    }
+  }
+  
+  # Check the ExpectedClusters specification
+  
+  if ( idf["expectedclusters",1] != "" ) {
+    x <- as.numeric(idf["expectedclusters",1])
+    if (is.na(x) || x < 1 ) {
+      perror("IDF error in AEExpectedClusters: Invalid value  (",idf["expectedclusters",1],")")
+      q(status=1)
+    }
+    opt$nc <- x
+  }
+  
+  # AdditionalAttributes - characteristics (optional) exist in the SDRF
+  
+  if ( "additionalattributes" %in% rownames(idf) && idf["additionalattributes",1] != "" ) {
+    idf.attrs <- idf["additionalattributes",]
+    
+    # exclude "" and ignore case
+    idf.attrs <- sapply(attrs[attrs!=""],tolower)
+    
+    # Check for fields absent in the SDRF
+    not.present <- (! idf.attrs %in% colnames(sdrf))
+    
+    if (sum(not.present)) {
+      perror("IDF error in EAAdditionalAttributes:",paste(idf.attrs[not.present],sep=",")," not found in SDRF")
+      q(status=1)
+    }
+  }
+}
+
+################################################################################
+# Second round SDRF field checks: beyond simple field presence 
+################################################################################
+
+## User can specify species, in which case we can discard irrelevant rows
+
+sdrf$organism <- gsub(" ","_",tolower(sdrf$organism))
+
+if ( !is.null(opt$species) ) {
+  if ( !opt$species %in% sdrf$organism ) {
+    perror("SDRF: Species ", opt$species, " not found")
+    q(status=1)
+  }
+  sdrf <- sdrf[sdrf$organism == opt$species, ]
+}
+
+pinfo("Species: ",paste(unique(sdrf$organism)),"\n")
+
+## SDRF-wide single-cell checks. This can result in filtering out rows, so do it
+## early. In the process we also work out what fastq files are required
+
+if ( opt$is_sc ) {
+  
+  ## single cell quality
+  
+  sc.quality.col <- 'single cell quality'
+  
+  if ( colsInSDRF(sc.quality.col, sdrf) ){
+    
+    sdrf <- setSDRFCol(sc.quality.col, sdrf, gsub(" +"," ", tolower(getSDRFCol(sc.quality.col, sdrf))))
+    single.cell.quality.counts <- table(getSDRFCol(sc.quality.col, sdrf))
+    
+    ## Discard cells from analysis that are low quality
+    ## OK, OK filtered or not OK
+    
+    pinfo("Discarding ",single.cell.quality.counts["not ok"]," runs/cells")
+    sdrf <- sdrf[getSDRFCol(sc.quality.col, sdrf) != 'not ok', ]
+  }
+  
+  # Check the single cell protocol
+  
+  protocol.corrections <- list(
+    'smart-like' = 'smart-seq',
+    'Smart-seq2' = 'smart-seq2',
+    '10xv2' = '10xV2'
+  )
+  
+  protocols <- getSDRFCol(sc.protocol.col, sdrf)
+  for (prot in names(protocol.corrections)){
+    protocols[protocols == prot] <- protocol.corrections[[prot]]
+  }
+  
+  sdrf <- setSDRFCol(sc.protocol.col, sdrf, protocols)
+  
+  # Check that all sc protocols are valid
+  
+  protocols <- tolower(protocols)
+  
+  not.valid.sc.protocol <- unique(protocols[! protocols %in% supported.single.cell.protocols])
+  
+  if ( length(not.valid.sc.protocol) ) {
+    perror("SDRF: Unsupported single cell protocol ", not.valid.sc.protocol)
+    q(status=1)
+  }
+  
+  # Ignore single-cell identifier for droplet-only experiments
+  
+  if (all(protocols %in% sc.droplet.protocols) && sc.identifier.col %in% factors) {
+    addWarning("You have supplied 'single cell identifier' for an exlusively droplet-based experiment. This column is meaningless in this context and will be ignored")
+    factors <- factors[factors != sc.identifier.col]
+    sdrf <- sdrf[, colnames(sdrf) != sc.identifier.col]
+  }
+  
+  # Correct layout for droplet libraries
+  
+  library.layout <- getSDRFCol('library_layout', sdrf)
+  library.layout[ library.layout == 'PAIRED' & is.droplet.protocol(protocols) ] <- 'SINGLE'
+  sdrf <- setSDRFCol('library_layout', sdrf, library.layout)
+  
+  ## For every run, derive required file fields
+  
+  # Rules for droplet protocols
+  # 10Xv1: ?
+  # 10Xv1a: read 1 = cDNA, read 2 = UMI barcode, index 1 = cell barcode, index 2 = sample barcode (not required)
+  # 10Xv1i: read 1 = interleaved cDNA + UMI barcode, read 2 = interleaved cDNA + UMI barcode, index 1 = cell barcode, index 2 = sample barcode (not required)
+  # 10Xv2: read 1 = cell + UMI barcodes, read 2 = cDNA, index 1 = sample barcode (not required)
+  # Drop-seq: read 1 = cell + UMI barcodes, read 2 = cDNA
+  
+  sc.required.fastq.fields = list(
+    '10xv1' = c('read2 file', 'read1 file'),    
+    '10xv1a' = c('read2 file', 'read1 file', 'index1 file'),         
+    '10xv1i' = c('read2 file', 'read1 file', 'index1 file'),
+    '10xv2' = c('read2 file', 'read1 file'),
+    'drop-seq' = c('read1 file', 'read2 file'), 
+    "smart-seq2" = 'fastq uri',
+    "smarter" = 'fastq uri',
+    "smart-like = 'fastq uri"
+  )
+  
+  row.required.fastq.fields <- sc.required.fastq.fields[match(protocols, tolower(names(sc.required.fastq.fields)))] 
+    
+  sc.optional.fastq.fields = list(
+    '10xv1' = c('index1 file', 'index2 file'),    
+    '10xv1a' = c('index2 file'),         
+    '10xv1i' = c('index2 file'),
+    '10xv2' = c('index1 file'),
+    'drop-seq' = c(),
+    "smart-seq2" = c(),
+    "smarter" = c(),
+    "smart-like" = c()
+  )
+
+  # Consider any of the optional file fields that occur in the SDRF
+  
+  row.optional.fastq.fields <- lapply(sc.optional.fastq.fields[match(protocols, tolower(names(sc.optional.fastq.fields)))], function(x) intersect(x, colnames(sdrf))) 
+  
+}else{
+
+  # For bulk, just check rows for fastq_uri
+  
+  row.required.fastq.fields <- rep(list('fastq_uri'), nrow(sdrf))
+  row.optional.fastq.fields <- rep(list(c()), nrow(sdrf))
+}
+
+## Check for run ID. If it's not there as 'run' it needs to be there as
+## 'ena_run'
+
+if ( ! colsInSDRF('run', sdrf) ) {
+  # ENA_RUN must be present
+  if ( ! colsInSDRF('ena run', sdrf) ) {
+    perror("SDRF: expected RUN or ENA_RUN - none found")
+    q(status=1)
+  }else{
+    addWarning("SDRF: run column not found, using ena_run")
+    sdrf$run <- getSDRFCol('ena_run', sdrf)
+    
+    ## fix the run names (should not include # )
+    sdrf$run <- gsub("#","_",sdrf$run)
+  }
+}
+
+################################################################################
+# Check that:
+# 1 - all the necessary file fields exist
+# 2 - they have defined values for compulsory field for their technology
+# 3 - the indicated files actually exist
+#
+# SDRF files have a FASTQ_URI column for specifying links to FASTQ files, and
+# for droplet techs we also have fields like 'read1 file', 'index1 file' etc,
+# which are just file names.
+#
+# The following assumes:
+#
+#  - FASTQ files can be found in the specified directories
+#  - Single-cell droplet protocols have one run per line with multiple files. We ignore the multiple FASTQ URIs
+#  - Bulk and SMART-like protocols have one line per file with a single FASTQ URI in each
+################################################################################
+
+all.required.fastq.fields <- unique(unlist(row.required.fastq.fields))
+fastq.fields.in.sdrf <- colsInSDRF(all.required.fastq.fields, sdrf)
+
+## Check the actual fields exist
+
+if (any(! fastq.fields.in.sdrf)){
+  perror(paste("FASTQ file field (s)", paste(all.required.fastq.fields[! fastq.fields.in.sdrf], collapse=','), 'missing'))
+  q(status=1)
+}
+
+## Determine required file names on each row using the derived field names
+
+row.files <- lapply(1:nrow(sdrf), function(row.no){
+  req.fields <- row.required.fastq.fields[[row.no]]
+  structure(basename(as.character(sdrf[row.no, req.fields])), names = req.fields)
+})
+
+## Check that the required fields are populated
+
+rows.with.undefined.files <- which(unlist(lapply(row.files, function(x) any(! populated(x)))))
+
+if (length(rows.with.undefined.files) > 0){
+  undefined.row.files <- paste(unlist(lapply(rows.with.undefined.files, function(x) paste(paste0('Row ', x, ':'), paste(names(row.files[[x]])[ ! populated(row.files[[x]])], collapse=',')))), collapse="\n")
+  
+  perror("SDRF: some rows have missing values for required files: \n", undefined.row.files)
+  q(status=1)
+}
+
+## Add in any optional files with defined values
+
+row.files <- lapply(1:nrow(sdrf), function(row.no){
+  opt.fields <- row.optional.fastq.fields[[row.no]]
+  if (length(opt.fields) > 0 ){
+    opt.files <- basename(sdrf[row.no, opt.fields])
+    names(opt.files) <- opt.fields
+    c(row.files[[row.no]], opt.files[populated(opt.files)])
+  }else{
+    row.files[[row.no]]
+  }
+})
+
+## Check that all specified files actually exist
+
+fastq.dir <- file.path(opt$data_dir,"raw_data", opt$raw_dir)
+rows.files.exist <- lapply(row.files, function(x) fastqFileExists(x, fastq.dir, subfolders=split.files.by.subfolders) )
+
+rows.with.missing.files <- which(unlist(lapply(rows.files.exist, function(x) any(! x))))
+
+if (length(rows.with.missing.files) > 0){
+  missing.row.files <- unlist(lapply(rows.with.missing.files, function(x) paste(paste0('Row ', x, ':'), paste(names(row.files[[x]])[ ! rows.files.exist[[x]]], collapse=','))))
+  
+  first_missing <- missing.row.files[1:min(length(missing.row.files),10)]
+  
+  perror("SDRF: some rows have missing files. Up to first 10 examples: \n", paste(first_missing, collapse = '\n'))
+  q(status=1)
+}
+
+## Check there are the required number of rows (and therefore files) for
+## paired-endedness
+
+# single-end runs
+se.runs <- unique(sdrf$run[!grepl("PAIRED", getSDRFCol('library_layout', sdrf),ignore.case=TRUE)])
+
+# paired-end runs
+pe.runs <- unique(sdrf$run[grepl("PAIRED", getSDRFCol('library_layout', sdrf),ignore.case=TRUE)])
+
+n.paired.run.files <- table(sdrf$run[sdrf$run %in% pe.runs])
+
+if(any(n.paired.run.files != 2)){
+  perror(paste('Paired runs', paste(names(n.paired.run.files[which(n.paired.run.files != 2)]), collapse=', '), 'did not have two run files'))
+  q(status=1)
+}
+
+## Finally, collapse to files per run
+
+run.fastq.files <- lapply(unique(sdrf$run), function(run){
+  unlist(row.files[sdrf$run == run])
+})
+names(run.fastq.files) <- unique(sdrf$run)
+
+## We're done parseing the SDRF, print some information on its content
+
+pinfo("Printing SDRF summary info")
 cat("Columns: ",ncol(sdrf),"\n")
 cat("Entries: ",nrow(sdrf),"\n")
 pinfo("Columns found in SDRF:")
 cat(paste(colnames(sdrf),collapse=","),"\n")
 
-## Factors should not be simultaneously comments 
-
-factors <- normalize.cols(colnames(sdrf)[grepl("^factorvalue",colnames(sdrf),ignore.case=TRUE)])
-comments <- normalize.cols(colnames(sdrf)[grepl("^comment",colnames(sdrf),ignore.case=TRUE)])
-characteristics <- normalize.cols(colnames(sdrf)[grepl("^characteristics",colnames(sdrf),ignore.case=TRUE)])
-
-common <- intersect(factors,comments)
-if (length(common)>0) {
-    if ( opt$atlas_mode==TRUE ) {
-        perror("SDRF: common factors and comments - ",paste(common,collapse=","))
-        q(status=1)
-    }
-    addWarning("SDRF: common factors and comments - ",paste(common,collapse=","))
-}
-
-common <- intersect(comments,characteristics)
-if (length(common)>0) {
-    if ( opt$atlas_mode==TRUE ) {
-        perror("SDRF: common characteristics and comments - ",paste(common,collapse=","))
-        q(status=1)
-    }
-    addWarning("SDRF: common characteristics and comments - ",paste(common,collapse=","))
-}
-
-## Load and check the IDF where provided
-
-idf <- NULL
-if ( !is.null(opt$idf_file) ) {
-    pinfo("Loading IDF...")
-    idf <- read.tsv(opt$idf_file,header=FALSE,comment.char="",fill=TRUE,quote="")
-    if (is.null(idf) ) {
-        perror("Error while loading IDF file ",opt$idf_file)
-        q(status=1)
-    }
-    pinfo("Loading IDF...done.")    
-    ## exclude blank lines
-    idf <- idf[idf$V1!="",,drop=FALSE]
-    cat("Columns: ",ncol(idf),"\n")
-    cat("Entries: ",nrow(idf),"\n")
-
-    ## SecondaryAccession may be non-unique
-    if ( sum(tolower(idf[,1])!="comment[secondaryaccession]") > 1 ) {
-        addWarning("IDF: Multiple 'SecondaryAccession' entries")
-    }
-
-    idf <- idf[tolower(idf[,1])!="comment[secondaryaccession]",]
-    
-    ## basic idf check (non unique rownames)
-    dups <- duplicated(idf[,1])
-    if ( sum(dups) > 0 ) {
-        dupss <- paste(idf[dups,1],sep=",",collapse=",")
-        perror("Duplicated entries: ",dupss)
-        q(status=1)
-    }
-  
-    ## error handling should be improved...
-    rownames(idf) <- tolower(gsub("\\s*\\]\\s*","",gsub("^\\s*COMMENT\\s*\\[\\s*","",as.character(idf[,1]),ignore.case=TRUE)))
-    idf <- idf[,-1,drop=FALSE]
-
-    ## be tolerant about the EA comments
-    rownames(idf) <- gsub("^ea","",rownames(idf))
-
-    ## initial check
-    if (! "sdrf file" %in% rownames(idf) ) {
-        perror("SDRF file missing from IDF file")
-        q(status=1)
-    }
-    if ( idf["sdrf file",1]!=basename(opt$sdrf_file) ) {      
-        perror("SDRF file in IDF (",idf["sdrf file",1],") differs from given sdrf file name ",basename(opt$sdrf_file))
-        q(status=1)
-    }
-    cat("IDF:",paste(rownames(idf),collapse=","),"\n")    
-
-    ##expectedclusters
-    ##
-    ## ExperimentType       differential|baseline (mandatory)
-    ## ExpectedClusters     may be empty
-    ## AdditionalAttributes - characteristics (optional) exist in the SDRF
-    ## AEExperimentType RNA-seq of coding RNA from single cells (single cell)
-    ## Protocol Name should match SDRF
-    ## Experimental Factor Name (mandatory) exist in the SDRF
-    ## note: factors and characteristics should always be lower case!! @Laura
-
-    expected.in.idf <- c()
-    if ( opt$is_sc ) {
-        expected.in.idf <- c("expectedclusters")
-        names(expected.in.idf) <- c("EAExpectedClusters")
-    }
-
-    if ( opt$atlas_mode ) {
-        expected.in.idf2 <- c("experimenttype","experimental factor name","protocol name")
-        names(expected.in.idf2) <- c("AEExperimentType","Experimental Factor Name","Protocol Name")
-        expected.in.idf <- c(expected.in.idf,expected.in.idf2)
-    }
-
-    not.present <- (!expected.in.idf%in%rownames(idf))
-    if ( sum(not.present)>0 ) {
-        perror("IDF incomplete. Missing ",paste(names(expected.in.idf)[not.present],sep=",",collapse=","))
-        q(status=1)
-    }
-
-    if ( opt$atlas_mode ) {
-        if ( sum(c("baseline","differential") %in% tolower(idf["experimenttype",1]))==0 ) {
-            perror("IDF error in EAExperimentType: Invalid value (",idf["experimenttype",1],") expected baseline or differential")
-            q(status=1)
-        }
-
-        ##AEExperimentType
-        expected.vals <- tolower(c("RNA-seq of coding RNA from single cells","RNA-seq of coding RNA"))
-        if ( sum( expected.vals %in% tolower(idf["aeexperimenttype",1]))==0 ) {
-            perror("IDF error in AEExperimentType: Invalid value (",idf["aeexperimenttype",1],") expected ",paste(expected.vals,sep=" or ",collapse=" or "))
-            q(status=1)
-        }
-
-        if ( expected.vals[1] %in% tolower(idf["aeexperimenttype",1]) ) {
-            opt$is_sc <- TRUE
-        }
-    }
-}
-
-if (opt$is_sc) {
-    pinfo("Single cell experiment")
-} 
-
-## Check mandactory columns (SDRF)
-
-exp.comment.cols <- c("LIBRARY_STRATEGY","LIBRARY_SOURCE","LIBRARY_SELECTION","LIBRARY_LAYOUT","FASTQ_URI")
-exp.characteristic.cols <- c()
-exp.factor.cols <- c()
-
-opt.cols <- c("ORGANISM","organism part","sex","spike in","molecule","technical replicate group","ENA_RUN","ENA_SAMPLE","Scan Name")
-
-expected.cols <- exp.cols
-expected.comment.cols <- exp.comment.cols
-expected.factor.cols <- exp.factor.cols
-expected.characteristic.cols <- exp.characteristic.cols
-
-## Single-cell specific
-
-sc.exp.cols <- c("Material Type","library_construction","single cell isolation")
-sc.exp.comment.cols <- c("LIBRARY_STRAND")
-sc.exp.factor.cols <- c()
-sc.exp.characteristic.cols <- c()
-sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file")
-
-if( opt$is_sc ) {
-    expected.cols <- append(expected.cols,sc.exp.cols)
-    expected.comment.cols <- append(exp.comment.cols,sc.exp.comment.cols)
-    expected.characteristic.cols <- append(exp.characteristic.cols,sc.exp.characteristic.cols)
-    expected.factor.cols <- append(exp.factor.cols,sc.exp.factor.cols)
-    opt.cols <- append(opt.cols,sc.opt.cols)
-}
-
-pinfo("Checking presence of columns...")
-colsInSDRF(expected.cols,sdrf)
-colsInSDRF(expected.characteristic.cols,sdrf,characteristic.cols=TRUE)
-colsInSDRF(expected.comment.cols,sdrf,comment.cols=TRUE)
-colsInSDRF(expected.factor.cols,sdrf,factor.cols=TRUE)
-pinfo("Checking the presence of columns...done.")
-
-
-## work with lower case names
-orig.col.names <- tolower(colnames(sdrf))
-## ignore spaces and _
-colnames(sdrf) <- normalize.cols(orig.col.names)
-
 ## print the values
 pinfo("Most frequent values per column...")
 for (col in tolower(c(expected.cols,expected.comment.cols,expected.factor.cols,expected.characteristic.cols)) ) {
-    # ignore spaces
-    col <- normalize.cols(col,FALSE)
-    tt <- table(sdrf[,col])
-    if (length(tt)==nrow(sdrf) ) {
-        pinfo(col,": single value per row")
-    } else {
-        pinfo(col,": ",length(tt)," unique values")
-    }
-}
-#######################
-## add optional columns
-pinfo("Checking optional columns...")
-xx <- colsInSDRF(opt.cols,sdrf,exit.on.error=FALSE)
-if ( length(xx) > 0 ) {
-    pinfo("Added ",paste(xx,collapse=","))
-    sdrf[,normalize.cols(xx)] <- -1
+  # ignore spaces
+  col <- normalize.cols(col,FALSE)
+  tt <- table(sdrf[,col])
+  if (length(tt)==nrow(sdrf) ) {
+    pinfo(col,": single value per row")
+  } else {
+    pinfo(col,": ",length(tt)," unique values")
+  }
 }
 
-sdrf$organism <- gsub(" ","_",tolower(sdrf$organism))
-species <- unique(sdrf$organism)
-cat("Species:",species,"\n")
-if (!is.null(opt$specie) ) {
-    if (!opt$specie%in%species) {
-        perror("SDRF: Specie ",opt$specie," not found")
-        q(status=1)
-    }
-    species <- c(opt$specie)
-}
-## technical replicates
-## should be mandatory...lets be a bit flexible
-if ( ! normalize.cols("technical replicate group") %in% colnames(sdrf) ) {
-    sdrf[,normalize.cols("technical replicate group")] <- rep("",nrow(sdrf))
-    addWarning("SDRF: technical replicate group column missing (assuming no technical replicates)")
-} else {
-    ## some groups entries may be empty
-    ## use the source name to fill the missing values
-    nc <- normalize.cols("technical replicate group")
+################################################################################
+# We'll be making a config per species, and these sub-experiments will then we
+# analysed separately. So checks that with an experimental context (presence of
+# technical replication, consistency of spikeins etc) need to be done within
+# that species.
+################################################################################
 
-    # Consider that there are no tech rep groups if 1) all values are empty (''
-    # or NA) or 2) there is a single value
+sdrf.by.species <- split(sdrf, sdrf$organism)
 
-    tr <- sdrf[,nc]
+# Run the checks first
 
-    is.empty <- tr == "" | is.na(tr)
-    if (all(is.empty) || length(unique(tr)) == 1){
-        sdrf[,nc] <- ""
-    }else if ( any(is.empty) ){
-        perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values where some values are set")
-        q(status=1)
-    }
-}
+species.properties <- list()
 
-######
-## run
-if ( ! "run" %in% colnames(sdrf) ) {
-    ## ENA_RUN must be present
-    if ( ! normalize.cols("ena_run") %in% colnames(sdrf) ) {
-        perror("SDRF: expected RUN or ENA_RUN - none found")
-        q(status=1)
-    }
-    addWarning("SDRF: run column not found")
-    sdrf$run <- sdrf[,normalize.cols("ena_run")]
-}
-
-###############
-## runs /unique
-## fix the run names (should not include # )
-sdrf$run <- gsub("#","_",sdrf$run)
-# get unique runs
-runs <- unique(sdrf$run)
-cat("#runs:",length(runs),"\n")
-
-##########
-## factors
-factor.cols <- colnames(sdrf)[grepl("^factorvalue",gsub(" +","",tolower(orig.col.names)))]
-cat("#factors:",length(factor.cols),"\n")
-cat(factor.cols,"\n")
-sdfcols2save2tsv <- append(sdfcols2save2tsv,factor.cols)
-#######################
-## spike ins (optional)
-sin <- normalize.cols("spike in")
-spikein <- c("")
-if ( sin %in% colnames(sdrf) ) {
+for (species in names(sdrf.by.species)){
+  
+  species.sdrf <- sdrf.by.species[[species]]
+  
+  # Some default propertiesa
+  
+  properties <- list(
+    has.spikes = FALSE,
+    has.techreps = FALSE
+  )
+  
+  # Filtering could have removed all rows for a species
+  
+  if (nrow(species.sdrf) == 0){
+    perror(paste0('No rows remaining for ', species, ', check filtering'))
+    q(status=1)
+  }
+  
+  ## Spikes? Assert that there are no spike-ins unless the field is populated with
+  ## non-empty values of a single type.
+  
+  if ( colsInSDRF('spike_in', species.sdrf) ) {
     pinfo("Found 'spike in' column")
-    spikein <- unique(sdrf[,sin])
+    spikein <- unique(getSDRFCol('spike_in', species.sdrf))
     if ( length(spikein) > 1 ) {
-        ##print(spikein)
-        perror("SDRF error: Expected one or no spike ins (found ",length(spikein),").")
-        q(status=1)
+      perror("SDRF error: Expected one or no spike ins (found ",length(spikein),").")
+      q(status=1)
+    }else if (populated(spikein)){
+      properties$has.spikes <- TRUE
     }
-    spikein <- tolower(spikein)
-}
-
-
-##############
-## last checks
-layout.cols <- c("run","library_layout","ena_sample","library_layout","library_strand","technical replicate group")
-if ( opt$is_sc ) {
-    if (sdrf["single cell isolation"]%in%c("smart-seq","smart-seq2"))
-        layout.cols <- append(layout.cols,c("single cell identifier"))
-    ## add a few extra columns
-    opt.cols <- c("read1 file","read2 file","index1 file","index2 file","index3 file")
-    layout.cols  <- append(layout.cols,intersect(normalize.cols(opt.cols),colnames(sdrf)))
-}
-
-layout.cols <- unique(normalize.cols(layout.cols,FALSE))
-xx <- colsInSDRF(layout.cols,sdrf)
-##print(xx)
-
-###########
-## protocol
-if ( opt$is_sc ) {
-    prot.cols <- normalize.cols(c("library method","library_construction"))
-    prot.col <- prot.cols[prot.cols%in%colnames(sdrf)]
-    if ( is.null(prot.col) ) {
-        perror("SDRF: Column(s) not found: ",prot.cols[!prot.cols%in%colnames(sdrf)])
-        q(status=1)
-    }
-    pp <- unique(as.character(sdrf[,normalize.cols("library_construction")]))
-    ## smart-seq2 and smarter
-    supported.single.cell.protocols <- c("smart-seq2","smarter","smart-like","10xv2","10xv1","drop-seq","10xv1a")
-    not.in.pp <- pp[!tolower(pp)%in%supported.single.cell.protocols]
-    if ( length(not.in.pp) ) {
-        perror("SDRF: Unsupported single cell protocol ",not.in.pp)
-        q(status=1)
-    }
-}
-################################
-## IDF
-if ( !is.null(idf) ) {
-    ## ExpectedClusters     may be empty
-    if ( opt$nc == 0 && opt$is_sc ) {
-        ##
-        if ( idf["expectedclusters",1] != "" ) {
-            x <- as.numeric(idf["expectedclusters",1])
-            if (is.na(x) || x<1) {
-                perror("IDF error in AEExpectedClusters: Invalid value  (",idf["expectedclusters",1],")")
-                q(status=1)
-            }
-            opt$nc <- x
-        }
-    }
-    ## AdditionalAttributes - characteristics (optional) exist in the SDRF
-    if ( "additionalattributes" %in% rownames(idf) && 
-        idf["additionalattributes",1] != "" ) {
-        attrs <- idf["additionalattributes",]
-        ## exclude "" and ignore case
-        attrs <- sapply(attrs[attrs!=""],tolower)
-        not.present <- (!attrs %in%colnames(sdrf))
-        if (sum(not.present)) {
-            perror("IDF error in EAAdditionalAttributes:",paste(attrs[not.present],sep=",")," not found in SDRF")
-            q(status=1)
-        }
-        sdfcols2save2tsv <- unique(c(sdfcols2save2tsv,attrs))
-    }
-    ## Cross check idf with SDRF
-    if ( opt$atlas_mode ) {
-        ## - Protocol Name should match SDRF
-        ## attrs <- idf["protocol name",]
-        ## exclude "", case sensitive
-        ## attrs <- attrs[attrs!=""]
-        ## hmm, currently the sdrf may contain multiple protocol ref columns !?
-        
-        ## - Experimental Factor Name (mandatory) exist in the SDRF
-        attrs <- idf["experimental factor name",]
-        attrs <- attrs[attrs!=""]
-        ## all factors should be in lower case
-        if ( attrs != sapply(attrs,tolower) ) {
-            perror("IDF error in  Experimental Factor Name: values should be in lower case")
-            q(status)
-        }
-        ## and match the sdrf
-        fint <- sort(intersect(factor.cols,attrs))
-        funi <- sort(unique(c(factor.cols),attrs))
-        if ( fint!=funi ) {
-            perror("SDRF/IDF inconsistency: factor values do not match")
-            q(status=1)
-        }
-        sdfcols2save2tsv <- unique(c(sdfcols2save2tsv,factor.cols))
-    }
-}
-
-# Update the layout cols with the factors and char. of interest
-layout.cols <- unique(c(layout.cols,normalize.cols(sdfcols2save2tsv)))
-################################
-split.files.by.subfolders <- FALSE
-if ( nrow(sdrf) > 5090 || opt$fastq.splited.by.subfolders) {    
-    split.files.by.subfolders <- TRUE
-}
-################################
-confs <- list()
-for (specie in species) {
-    pinfo("Specie: ",specie)
-    conf.l <- matrix(ncol=1,nrow=0)
-    conf.l <- rbind(conf.l,paste0("# iRAPs configuration file for ",opt$name))
-    conf.l <- rbind(conf.l,paste0("# Generated ",date()," from ",opt$sdrf))
-    conf.l <- rbind(conf.l,paste0("name=",opt$name))
-    conf.l <- rbind(conf.l,paste0("species=",tolower(specie)))
-    conf.l <- rbind(conf.l,paste0("data_dir=",opt$data_dir))
-    conf.l <- rbind(conf.l,paste0("raw_folder=",opt$raw_dir))
-    conf.l <- rbind(conf.l,paste0("sop=",opt$sop))
-
-    conf.l <- rbind(conf.l,paste0("reference=",opt$reference))
-    conf.l <- rbind(conf.l,paste0("gtf_file=",opt$gtf_file))
+  }
+  
+  ## Check for technical replicates . Consider that there are no tech rep groups
+  ## if:
+  ##   1) all values are empty ('' or NA) 
+  ##   or 2) there is a single value
+  
+  if ( colsInSDRF(techrep.col, species.sdrf) ) {
+    tr <- getSDRFCol(techrep.col, species.sdrf)
+    n.techrep.groups <- length(unique(tr))
     
-    ## spikein
-    #
-    # Value will be '' if no column was found, or if the column is empty (in
-    # which case we assert no spikes). 
+    is.empty <- tr == "" | is.na(tr) | tr == 'NA' | tr == 'not applicable'
 
-    if ( grepl("ercc.*",spikein) ) {
-        conf.l <- rbind(conf.l,paste0("spikein_fasta=ERCC"))
-    } else if ( spikein == 'none' || gsub(' ', '', spikein) == '') {
-        conf.l <- rbind(conf.l,paste0("spikein_fasta="))
-    } else {
-        conf.l <- rbind(conf.l,paste0("#spikein_fasta=",spikein))
+    if ( (! all(is.empty)) && any(is.empty) ){
+      perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values where some values are set")
+      q(status=1)
+    }else if(n.techrep.groups == 1 ||  n.techrep.groups == nrow(species.sdrf)){
+      
+      # If the technica replicate field has been set, but the group numbers don't
+      # indicate technical replication (i.e. every run has its own group, or
+      # there's only only 1), we would normally say that there is in fact no
+      # technical replication. But since droplet protocols have multiple cells per
+      # run we'll give these entries the benefit of the doubt.
+      
+      if (opt$is_sc && all(is.droplet.protocol(unique(getSDRFCol('library construction', species.sdrf))))){
+        properties$has.techrep <- TRUE
+      }
+    }else{
+      properties$has.techrep <- TRUE
     }
-    ## slice per specie
-    sdrf.tmp <- sdrf[sdrf$organism==specie,,drop=FALSE]
-    sruns <- unique(sdrf.tmp$run)
-    cat("#runs:",length(sruns),"\n")
-
-    #print(layout.cols)
-    #print(colnames(sdrf.tmp))
-    layout <- sdrf.tmp[,layout.cols,drop=FALSE]
-    layout <- layout[!duplicated(layout$run),,drop=FALSE]
-    rownames(layout) <- layout$run
-    run.pp <- ""
-    ##
-    if ( opt$is_sc ) {
-        run.pp <- unique(as.character(sdrf.tmp[,normalize.cols("library construction")]))        
-        ## single protocol
-        if ( length(run.pp)>1 ) {
-            perror("multiple library construction values:",paste(run.pp,sep=","))
-            q(status=1)
-        }
-
-        if ( length(run.pp)==0 ) {
-            perror("Missing 'library construction' values/column")
-            q(status=1)
-        }
-        if ( run.pp == "smart-like" ) run.pp <- "smart-seq"
-        ## shouldn't be necessary
-        if ( run.pp == "Smart-seq2" ) run.pp <- "smart-seq2"
-        if ( run.pp == "10xv2" ) run.pp <- "10xV2"
-        conf.l <- rbind(conf.l,paste0("sc_protocol=",run.pp))
-        pinfo("sc_protocol=",run.pp)
-        ## single cell quality
-        if ( normalize.cols("single cell quality") %in% colnames(layout) ) {
-            ## OK, OK filtered or not OK
-            scq <- normalize.cols("single cell quality")
-            layout[,scq] <- gsub(" +"," ",tolower(layout$"single cell quality"))
-            cq <- table(layout[,scq])
-            cat("single cell quality:\n")
-            #print(cq)
-            ## discard cells from analysis that are low quality
-            pinfo("Discarding ",cq["not ok"]," runs/cells")
-            layout <- layout[layout[,scq]!="not ok",,drop=FALSE]
-        }
+  }
+  
+  # ENA sample. Check that the sample names don't suggest we should have technical
+  # replicates when we don't
+  
+  if ( colsInSDRF('ena_sample', species.sdrf) ) {
+    samples <- length(unique(getSDRFCol('ena_sample', species.sdrf)))
+    runs <- length(unique(getSDRFCol('run', species.sdrf)))
+    has.techrep.from.samples <- sum(samples != runs) > 0
+    if ( has.techrep.from.samples != properties$has.techrep  ) {
+      pinfo("Technical replicates: SDRF column ", techrep.col, ' ', properties$has.techrep," vs ena_sample ", has.techrep.from.samples)
+      addWarning("Technical replicate group inconsistent with ena_sample")
     }
-    ##
-    if ( nrow(layout)==0 ) {
-        perror("No samples, nothing to do")
-        next
+  }
+  
+  if (opt$is_sc){
+    
+    # Need a single protocol
+    
+    species.protocols <- unique(getSDRFCol(sc.protocol.col, species.sdrf))
+    if (length(species.protocols) > 1){
+      perror("multiple library construction values:",paste(species.protocols,sep=","))
+      q(status=1)
     }
-    #################################################
-    ## technical replicates
-    trn <- normalize.cols("technical replicate group")
-    ue <- length(unique(sdrf[,trn]))
-    has.tr <- (ue!=nrow(sdrf) && ue!=1)
-    if ( ue==1 ) {
-        ## it may be the case for SC (10x) that only ue==1
-        if (sdrf[1,trn]!="NA" && sdrf[1,trn]!="" && sdrf[1,trn]!="not applicable" ) {
-            has.tr <- TRUE
-        }
-    }
-
-    esn <- normalize.cols("ena_sample")
-    if ( esn %in% colnames(sdrf) ) {
-        samples <- length(unique(layout$ena_sample))
-        runs <- length(unique(layout$run))
-        has.tr2 <- sum(samples!=runs)>0
-        if ( has.tr2!=has.tr  ) {
-            pinfo("SDRF column ",has.tr," vs ena_sample ",has.tr2)
-            addWarning("Technical replicate group inconsistent with ena_sample")
-            ##q(status=1)
-        }
-    }
-    if(!has.tr) {
-        pinfo("Technical replicates: no")
-        conf.l <- rbind(conf.l,paste0("#technical.replicates="))
-    } else {
-        pinfo("Technical replicates: yes")
-        x<-layout[order(layout[,normalize.cols("technical replicate group")]),normalize.cols(c("run","technical replicate group"))]
-        ##
-        v1 <- aggregate(x$run,by=list(v1=x[,2]),FUN=paste,collapse=",")
-        ##print(head(v1))
-        ##print(tail(v1))
-        ##print("--------------")
-        tr <- paste(unlist(v1$x),collapse=";",sep="")
-        tr.labels <- paste(v1$v1,collapse=";",sep="")
-
-        if ( ! run.pp %in% c("10xV2") ) {
-            ## technical replicates are encoded in the sample
-            conf.l <- rbind(conf.l,paste0("technical_replicates=",tr))
-            conf.l <- rbind(conf.l,paste0("technical_replicates_labels=",tr.labels))
-        }
-    }
-
-    #################
-    ## LIBRARY LAYOUT
-    ## se
-    se.runs <- rownames(layout)[!grepl("PAIRED",layout[,normalize.cols("library_layout")],ignore.case=TRUE)]
-    ## pe
-    pe.runs <- rownames(layout)[grepl("PAIRED",layout[,normalize.cols("library_layout")],ignore.case=TRUE)]
-
-    ##########################
-    ## clusters
-    clusters.window <- opt$nc_window
-    if ( opt$nc < 2 ) {
-        opt$nc <- round(log2(nrow(layout)))
-    }
-    num.min.c <- max(round(opt$nc-clusters.window/2,0),2)
-    num.max.c <- num.min.c+clusters.window
-    pinfo("#clusters:",num.min.c,"-",num.max.c)
-    conf.l <- rbind(conf.l,paste0("min_clusters=",num.min.c))
-    conf.l <- rbind(conf.l,paste0("max_clusters=",num.max.c))
-    norm.fastq.uri <- normalize.cols("fastq_uri")
-    ############################
-    ##Runs
-    if ( !opt$check_only ) {
-        #########################################
-        ## save factors and characteristics
-        if ( length(sdfcols2save2tsv)>0 ) {
-            ofile <- paste0(opt$out_conf,".metadata.tsv")
-            to.save <- sdfcols2save2tsv
-            if (has.tr) { to.save <- c(to.save,"technical replicate group") }
-            layout2save <- layout[,normalize.cols(to.save),drop=FALSE]
-            layout2save <- cbind(run=rownames(layout2save),layout2save)
-            write.tsv(layout2save,file=ofile,header=TRUE)
-            pinfo("Created ",ofile)
-            conf.l <- rbind(conf.l,paste0("extra_metadata=",basename(ofile)))            
-        }
-
-        ##
-        for (run in sruns ) {
-            ## lib
-            sfiles <- ""
-            v1 <- sdrf.tmp[sdrf.tmp$run==run,norm.fastq.uri][1]
-            #print(v1)
-            if ( !is.na(v1) && v1 !="" ) {
-                sfiles <- sort(basename(sdrf.tmp[sdrf.tmp$run==run,norm.fastq.uri]))
-            }
-            ##if ( length(sfiles) == 0 || sfiles == "" ) {
-            if ( tolower(run.pp) %in% c("10xv2","10xv1","10xv1a","drop-seq") ) {
-                ## if empty URI then look for read1 and read2
-                if ( "read1 file" %in% colnames(sdrf.tmp) ) {
-                    sfiles <- sdrf.tmp[sdrf.tmp$run==run,"read1 file"]
-                    if ("read2 file" %in% colnames(sdrf.tmp) ) {
-                        sfiles <- c(sfiles,sdrf.tmp[sdrf.tmp$run==run,"read2 file"])
-                    }
-                    if ("index1 file" %in% colnames(sdrf.tmp) ) {
-                        sfiles <- c(sfiles,sdrf.tmp[sdrf.tmp$run==run,"index1 file"])
-                    }
-                    sfiles <- sfiles[sfiles!=""]
-                    sfiles <- sfiles[sfiles!="-1"]
-                } else {                    
-                    perror("SDRF: No raw data file for ",run)                
-                    q(status=1)
-                }
-            }
-            #########################################
-            ## 
-            exp.files <- c()
-            if ( opt$is_sc==TRUE && run.pp %in% c("10xV2","drop-seq","10xV1") ) {
-                ## "index1 file" is optional
-                exp.files <- c("read2 file","read1 file")
-                if ( sum(!exp.files %in% colnames(sdrf))>0 ) {
-                    perror("SDRF: missing columns for ",run.pp," - expected ",paste(exp.files,collapse=","))
-                    q(status=1)
-                }
-                ## we must have files
-                files <- sdrf.tmp[sdrf.tmp$run==run,exp.files]
-                if ( sum(files!="")!=length(exp.files)) {
-                    perror("SDRF: files missing for ",run,"")
-                    q(status=1)
-                }
-                ##,"index1 file"
-                files.cols <- c(exp.files,"index1 file")
-                sfiles <- sdrf.tmp[sdrf.tmp$run==run,files.cols]
-                names(sfiles) <- files.cols
-                sfiles <- sfiles[names(sfiles)[sfiles!="-1"]]
-            }
-            ## 10xV1*
-            if ( opt$is_sc==TRUE && run.pp %in% c("10xV1a") ) {
-                ## "index2 file" is optional
-                exp.files <- c("read2 file","read1 file","index1 file")
-                if ( sum(!exp.files %in% colnames(sdrf))>0 ) {
-                    perror("SDRF: missing columns for ",run.pp," - expected ",paste(exp.files,collapse=","))
-                    q(status=1)
-                }
-                ## we must have files
-                files <- sdrf.tmp[sdrf.tmp$run==run,exp.files]
-                if ( sum(files!="")!=length(exp.files)) {
-                    perror("SDRF: files missing for ",run,"")
-                    q(status=1)
-                }
-                ##,"index1 file"
-                files.cols <- c(exp.files,"index2 file")
-                sfiles <- sdrf.tmp[sdrf.tmp$run==run,files.cols]
-                names(sfiles) <- files.cols
-                sfiles <- sfiles[names(sfiles)[sfiles!="-1"]]
-            }
-            ##
-            if ( run %in% pe.runs && length(sfiles)!=2) {
-                ## do not fail for some protocols
-                do.not.fail <- FALSE
-                if (opt$is_sc ) {
-                    if ( run.pp %in% c("10xV2") ) {
-                        ## more than 2 files expected
-                        do.not.fail <- TRUE
-                    }
-                }
-                if (!do.not.fail) {
-                    perror("SDRF: PE run ",run," does not have the 2 fastq files")
-                    q(status=1)
-                }
-            }
-            ssfiles <- paste(opt$raw_dir,"/",sfiles,collapse=" ",sep="")
-            ## cache info files
-            ## validate files and collect info
-            dir <- paste0(opt$data_dir,"/raw_data")
-            if ( ! file.exists(dir) ) {
-                perror("Folder ",dir," not found")
-                q(status=1)
-            }
-            info.file <- checkFiles(sfiles,subfolders=split.files.by.subfolders,opt=opt)
-            ## sed - hack for single cell
-            ## note/warning: there is an assumption that the lib name (file basename prefix)  corresponds to the run name. The code needs to be changed if that is not the case.
-            rr <- system(paste0("cat ",info.file,"|sed -E 's/_L[0-9]+_R[A0-9]+_[0-9]+//'"),intern=TRUE)
-            conf.l <- rbind(conf.l,matrix(rr,ncol=1))
-            ###########################################
-            ## strand
-            strand <- layout[run,normalize.cols("library_strand")]
-            ## print(strand)
-            if ( grepl("(first|second)",strand ) ) {
-                ## l prefix no longer needed
-                if ( grepl("first",strand ) ) 
-                    conf.l <- rbind(conf.l,paste0("",run,"_strand=first"))
-                else
-                    conf.l <- rbind(conf.l,paste0("",run,"_strand=second"))
-            } else {
-                conf.l <- rbind(conf.l,paste0("#",run,"_strand=both"))
-            }
-            ## 
-            ## 10x,drop-seq, ...
-            ## index,cell,umi
-            if ( tolower(run.pp) %in% c("10xv2","10xv1","10xv1a","drop-seq") ) {
-                ## No need to check if values exist, already done
-                ## but check files...
-                exp.files.cols <- names(sfiles)
-                exp.files <- sdrf.tmp[sdrf.tmp$run==run,exp.files.cols]
-                checkFiles(exp.files,validator.cmd="fastq_info",subfolders=split.files.by.subfolders,opt=opt)
-                if ( "index1 file" %in% exp.files.cols) 
-                    conf.l <- rbind(conf.l,paste0("",run,"_index1=",exp.files[1]))
-                if ( "index2 file" %in% exp.files.cols) 
-                    conf.l <- rbind(conf.l,paste0("",run,"_index2=",exp.files[2]))
-                sss <- as.numeric(as.factor(sdrf.tmp[,"technical replicate group"]))[sdrf.tmp$run==run]
-                conf.l <- rbind(conf.l,paste0("",run,"_sample=",sss))
-                ## not PE but SE
-                pe.runs <- pe.runs[pe.runs %in% run]
-                se.runs <- c(se.runs,run)
-            }
-        }
-    }
-    ##  l prefix no longer needed
-    conf.l <- rbind(conf.l,paste0("se=",paste(gsub("^","",se.runs),collapse=" ")))
-    conf.l <- rbind(conf.l,paste0("pe=",paste(gsub("^","",pe.runs),collapse=" "))) 
-    confs[[specie]] <- conf.l
+  }
  
+  species.properties[[species]] <- properties 
 }
+
+# With all checks done, we can stop if no further output is required
 
 if ( opt$check_only ) {
-    printAllWarnings()
-    pinfo("SDRF/IDF looks OK!")    
-    q(status=0)
+  printAllWarnings()
+  pinfo("SDRF/IDF looks OK!")    
+  q(status=0)
 }
 
-if ( length(confs)==0 ) {
-        perror("Unable to create configuration file, see above errors")
-        q(status=1)
-}
-##
-if ( length(names(confs))>1) {
-    for (specie in names(confs) ) {
-        ofile <- paste0(opt$out_conf,"_",specie,".conf")
-        write.table(confs[[specie]],file=ofile,row.names=FALSE,col.names=FALSE,quote="")
-        pinfo("Created ",ofile)
+# Now generate config and metadata
+
+configs <- lapply(names(sdrf.by.species), function(species){
+  
+  species.sdrf <- sdrf.by.species[[species]]
+  properties <- species.properties[[species]]
+  
+  # layout is the SDRF with the duplicated lanes for paired end removed
+  species.layout <- species.sdrf[!duplicated(species.sdrf$run),,drop=FALSE]
+  rownames(species.layout) <- species.layout$run
+  
+  ## Anything other than ERCC will be commented
+  
+  spikes.conf="spikein_fasta="
+  
+  if (properties$has.spikes){
+    spikein <- tolower(unique(getSDRFCol('spike_in', sdrf)))
+    if ( grepl("ercc.*",spikein) ) {
+      spikes.conf="spikein_fasta=ERCC"
+    }else{
+      spikes.conf=paste0("#spikein_fasta=",spikein)
     }
-} else {
-    ofile <- paste0(opt$out_conf,".conf")
-    write.table(confs[1],file=ofile,row.names=FALSE,col.names=FALSE,quote=FALSE)
-    pinfo("Created ",ofile)
+  }
+  
+  ## Set up for technical replication (or not)
+  
+  techreps.conf=#technical_replicates="
+  
+  if(properties$has.techrep) {
+    
+    # Subset the layout to get samples and replicate groups
+    techreps.runs <- getSDRFCol(c('run', techrep.col), species.layout, order.by = techrep.col)
+    
+    # Group runs/samples by techrep group
+    techreps.by.group <- aggregate( techreps.runs$run, by=list(techrep.group=techreps.runs[,2]), FUN=paste, collapse="," )
+    
+    techrep.run.groups <- paste(unlist(techreps.by.group$x),collapse=";",sep="")
+    techrep.group.labels <- paste(techreps.by.group$techrep.group,collapse=";",sep="")
+    
+    techreps.conf = paste(paste0("technical_replicates=", techrep.run.groups), paste0("technical_replicates_labels=",techrep.group.labels), sep = "\n")  
+  }
+  
+  # SC prototol
+  
+  sc.prot.conf = c()
+  sc.clusters.conf = c()
+  
+  if (opt$is_sc){
+    sc.prot.conf = paste0("sc_protocol=", getSDRFCol(sc.protocol.col, species.sdrf)[1])
+    
+    ## Decide what range of K values to try. Use a window around the provided
+    ## central k
+    
+    # Guess at a central K when not provided
+    
+    if ( opt$nc < 2 ) {
+      opt$nc <- round(log2(nrow(layout)))
+    }
+    
+    num.min.c <- max(round(opt$nc - opt$nc_window/2,0),2)
+    num.max.c <- num.min.c + opt$nc_window
+    
+    sc.clusters.conf = c(
+      paste0("min_clusters=",num.min.c),
+      paste0("max_clusters=",num.max.c)
+    )
+  }
+  
+  # Run-wise info
+  info.conf <- c()
+  
+  # Get the combined .info file content of each run
+  
+  run.info <- unlist(lapply(species.layout$run, getRunInfo ))
+  if (! is.null(run.info)){
+    info.conf <- run.info
+  }
+  
+  # Generate config file content
+  
+  config = c(
+    paste("# iRAPs configuration file for", opt$name),
+    paste("# Generated", date(), "from", opt$sdrf),
+    paste0("name=", opt$name),
+    paste0("species=", tolower(species)),
+    paste0("data_dir=", opt$data_dir),
+    paste0("raw_folder=", opt$raw_dir),
+    paste0("sop=", opt$sop),
+    paste("include", opt$species_conf),
+    paste0("se=",paste(gsub("^","",se.runs),collapse=" ")),
+    paste0("pe=",paste(gsub("^","",pe.runs),collapse=" ")),
+    spikes.conf,
+    techreps.conf,
+    sc.prot.conf,
+    sc.clusters.conf,
+    info.conf
+  )
+  
+  # Generate metadata file content to save
+  
+  metadata <- NULL
+  
+  sdfcols2save2tsv <- unique(c(
+    factor.cols,
+    idf.factors,
+    idf.attrs,
+    techrep.col
+  ))
+  
+  if (length(sdfcols2save2tsv) > 0){
+    metadata <- getSDRFCol(sdfcols2save2tsv, species.layout, drop = FALSE)
+    metadata <- cbind(run=rownames(metadata),metadata)
+  }
+  
+  list(config=config, metadata=metadata)
+})
+
+names(configs) <- names(sdrf.by.species)
+
+
+if ( length(confs)==0 ) {
+  perror("Unable to create configuration file, see above errors")
+  q(status=1)
 }
+
+## Write final outputs
+
+for (species in names(configs)){
+  
+  # If we've had multiple species then apply an appropriate suffix
+  
+  species_suffix=''
+  if (length(configs) > 1){
+    species_suffix <- paste0("_", species)
+  }
+  
+  config <- configs[[species]]$config
+  metadata <- configs[[species]]$metadata
+  
+  conf.file <- paste0(opt$out_conf, species_suffix, ".conf")
+  meta.file <- paste0(opt$out_conf, species_suffix,".metadata.tsv")
+  
+  # If there is metadata then point to it from the config file
+  
+  if ( ! is.null(metadata)){
+    config <- c(config, paste0("extra_metadata=", basename(meta.file)))
+    write.tsv(meta.file, file=meta.file, header=TRUE)
+    pinfo("Created ", meta.file)
+  }
+  
+  writeLines(config, con = conf.file)
+  pinfo("Created ", conf.file)
+}
+
 printAllWarnings()
 pinfo("All done")
 q(status=0)

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -1079,7 +1079,7 @@ for (species in names(configs)){
   
   if ( ! is.null(metadata)){
     config <- c(config, paste0("extra_metadata=", basename(meta.file)))
-    write.tsv(meta.file, file=meta.file, header=TRUE)
+    write.tsv(metadata, file=meta.file, header=TRUE)
     pinfo("Created ", meta.file)
   }
   

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -738,17 +738,24 @@ row.files <- lapply(1:nrow(sdrf), function(row.no){
   }
 })
 
-## Check that all specified files actually exist
+## Provided we're not just checking file validity, check that all specified
+## files actually exist
 
 if ( ! opt$check_only ) {
   
   fastq.dir <- file.path(opt$data_dir,"raw_data", opt$raw_dir)
   rows.files.exist <- lapply(row.files, function(x) fastqFileExists(x, fastq.dir, subfolders=split.files.by.subfolders) )
   
-  first_missing <- missing.row.files[1:min(length(missing.row.files),10)]
+  rows.with.missing.files <- which(unlist(lapply(rows.files.exist, function(x) any(! x))))
   
-  perror("SDRF: some rows have missing files. Up to first 10 examples: \n", paste(first_missing, collapse = '\n'))
-  q(status=1)
+  if (length(rows.with.missing.files) > 0){
+    missing.row.files <- unlist(lapply(rows.with.missing.files, function(x) paste(paste0('Row ', x, ':'), paste(names(row.files[[x]])[ ! rows.files.exist[[x]]], collapse=','))))
+    
+    first_missing <- missing.row.files[1:min(length(missing.row.files),10)]
+    
+    perror("SDRF: some rows have missing files. Up to first 10 examples: \n", paste(first_missing, collapse = '\n'))
+    q(status=1)
+  }
 }
 
 ## Check there are the required number of rows (and therefore files) for

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -491,13 +491,13 @@ if ( !is.null(opt$idf_file) ) {
   
   if ( "additionalattributes" %in% rownames(idf) && idf["additionalattributes",1] != "" ) {
     idf.attrs <- idf["additionalattributes",]
-    
+
     # exclude "" and ignore case
-    idf.attrs <- sapply(idf.attrs[idf.attrs!=""],tolower)
-    
+    idf.attrs <- sapply(idf.attrs[which(idf.attrs != "" && ! is.na(idf.attrs))],tolower)
+
     # Check for fields absent in the SDRF
     not.present <- (! idf.attrs %in% normalize.cols(colnames(sdrf)))
-    
+
     if (sum(not.present)) {
       perror("IDF error in EAAdditionalAttributes:",paste(idf.attrs[not.present],sep=",")," not found in SDRF")
       q(status=1)

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -44,22 +44,22 @@ usage <- "irap_sdrf2conf --name exp_name --species species --sdrf file --out_con
 filenames <- c("sdrf_file","idf_file")
 
 option_list <- list(
-    make_option(c("-n", "--name"), type="character", dest="name", default=NULL, help="(short) name of the experiment (no spaces)"),
-    make_option(c("--species"), type="character", dest="species", default=NULL, help="Species name."),
-    make_option(c("--species_conf"), type="character", dest="species_conf", default=NULL, help="iRAP species config file."),
-    make_option(c("--data_dir"), type="character", dest="data_dir", default=".", help="iRAP's toplevel data directory"),
-    make_option(c("--raw_dir"), type="character", dest="raw_dir", default=".", help="fastq directory"),
-    make_option(c("--sop"), type="character", dest="sop", default=NULL, help="iRAP's toplevel data directory"),
-    make_option(c("--nc"), type="numeric", dest="nc", default=0, help="estimated number of clusters [default %default]"),
-    make_option(c("--nc_window"), type="numeric", dest="nc_window", default=10, help="Clusters window [default %default]"),  
-    make_option(c("-s", "--sdrf"), type="character", dest="sdrf_file", default=NULL, help="SDRF file name"),
-    make_option(c("-i", "--idf"), type="character", dest="idf_file", default=NULL, help="IDF file name"),
-    make_option(c("--sc"), action="store_true",default=FALSE,dest="is_sc",help="Single cell experiment?. Default is FALSE."),
-    make_option(c("-c","--check_only"),action="store_true",dest="check_only",default=FALSE,help="Checks the sdrf/idf but skips the generation of the configuration file."),
-    make_option(c("-v","--verbose"),action="store_true",dest="verbose",default=FALSE,help="Produce verbose output."),
-    make_option(c("--atlas"),action="store_true",dest="atlas_mode",default=FALSE,help="Enable more stringent checks for the sdrf/idf files (for ExpressionAtlas)"),
-    make_option(c("--debug"),action="store_true",dest="debug",default=FALSE,help="Debug mode"),
-    make_option(c("--subfolders"),action="store_true",dest="fastq.splited.by.subfolders",default=FALSE,help="Are the files distributed across subfolders"),
+  make_option(c("-n", "--name"), type="character", dest="name", default=NULL, help="(short) name of the experiment (no spaces)"),
+  make_option(c("--species"), type="character", dest="species", default=NULL, help="Species name."),
+  make_option(c("--species_conf"), type="character", dest="species_conf", default=NULL, help="iRAP species config file."),
+  make_option(c("--data_dir"), type="character", dest="data_dir", default=".", help="iRAP's toplevel data directory"),
+  make_option(c("--raw_dir"), type="character", dest="raw_dir", default=".", help="fastq directory"),
+  make_option(c("--sop"), type="character", dest="sop", default=NULL, help="iRAP's toplevel data directory"),
+  make_option(c("--nc"), type="numeric", dest="nc", default=0, help="estimated number of clusters [default %default]"),
+  make_option(c("--nc_window"), type="numeric", dest="nc_window", default=10, help="Clusters window [default %default]"),  
+  make_option(c("-s", "--sdrf"), type="character", dest="sdrf_file", default=NULL, help="SDRF file name"),
+  make_option(c("-i", "--idf"), type="character", dest="idf_file", default=NULL, help="IDF file name"),
+  make_option(c("--sc"), action="store_true",default=FALSE,dest="is_sc",help="Single cell experiment?. Default is FALSE."),
+  make_option(c("-c","--check_only"),action="store_true",dest="check_only",default=FALSE,help="Checks the sdrf/idf but skips the generation of the configuration file."),
+  make_option(c("-v","--verbose"),action="store_true",dest="verbose",default=FALSE,help="Produce verbose output."),
+  make_option(c("--atlas"),action="store_true",dest="atlas_mode",default=FALSE,help="Enable more stringent checks for the sdrf/idf files (for ExpressionAtlas)"),
+  make_option(c("--debug"),action="store_true",dest="debug",default=FALSE,help="Debug mode"),
+  make_option(c("--subfolders"),action="store_true",dest="fastq.splited.by.subfolders",default=FALSE,help="Are the files distributed across subfolders"),
   make_option(c("-o", "--out_conf"), type="character",default=NULL,help="Filename of the new iRAP's configuration file.")
 )
 
@@ -78,75 +78,75 @@ pdebug.enabled <- opt$debug
 
 warnings.lst <- c()
 addWarning <- function(...) {
-    warnings.lst <- append(warnings.lst,paste0(...))
-    assign("warnings.lst",warnings.lst,envir = .GlobalEnv)
+  warnings.lst <- append(warnings.lst,paste0(...))
+  assign("warnings.lst",warnings.lst,envir = .GlobalEnv)
 }
 
 printAllWarnings <- function() {
-    n <- length(warnings.lst)
-    if ( n > 0 ) return
-    pinfo(n," warnings. Unique entries:")
-    prints <- sapply(unique(warnings.lst),pwarning)
+  n <- length(warnings.lst)
+  if ( n > 0 ) return
+  pinfo(n," warnings. Unique entries:")
+  prints <- sapply(unique(warnings.lst),pwarning)
 }
 
 # Print info only in the verbose case
 
 print.info <- function(...){
-    if (opt$verbose){
-        pinfo(paste(...))
-    }
+  if (opt$verbose){
+    pinfo(paste(...))
+  }
 }
 
 # Simplify column names
 
 normalize.cols <- function(vals,strip.brackets=TRUE) {
-    ## try to workaround typos & inconsistencies
-    x <- vals
-    if (strip.brackets)
-        x <- gsub("\\].*","",gsub(".*\\[","",x))
-    else {
-        x <- gsub(" +\\]","]",gsub(" +\\[","[",x))
-        x <- gsub("] +","]",x)
-    }
-    # a space or underscore seems to be the same thing
-    x <- gsub("_+"," ",x) ## no underscores
-    return(tolower(gsub(" +"," ",x))) ##lowercase and single space
+  ## try to workaround typos & inconsistencies
+  x <- vals
+  if (strip.brackets)
+    x <- gsub("\\].*","",gsub(".*\\[","",x))
+  else {
+    x <- gsub(" +\\]","]",gsub(" +\\[","[",x))
+    x <- gsub("] +","]",x)
+  }
+  # a space or underscore seems to be the same thing
+  x <- gsub("_+"," ",x) ## no underscores
+  return(tolower(gsub(" +"," ",x))) ##lowercase and single space
 }
 
 # Check for SDRF column presence
 
 colsInSDRF <- function(cols, sdrf, comment.cols=FALSE,  characteristic.cols=FALSE, factor.cols=FALSE, exit.on.error = FALSE) {
-
-    if ( length(cols) == 0 ) return()
-
-    sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=FALSE)
-    to.check.cols <- normalize.cols(cols,strip.brackets=FALSE)
-    if (comment.cols) {
-        to.check.cols <- paste("comment[",to.check.cols,"]",sep="")
-    }
-    if (factor.cols) {
-        to.check.cols <- paste("factorvalue[",to.check.cols,"]",sep="")
-    }
-    if (characteristic.cols) {
-        to.check.cols <- paste("characteristics[",to.check.cols,"]",sep="")
-    }
-    if ( !comment.cols && ! characteristic.cols && !factor.cols ) {        
-        sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=TRUE)
-        to.check.cols <- normalize.cols(cols,strip.brackets=TRUE)
-    }
-    found <- to.check.cols %in% sdrf.cols
+  
+  if ( length(cols) == 0 ) return()
+  
+  sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=FALSE)
+  to.check.cols <- normalize.cols(cols,strip.brackets=FALSE)
+  if (comment.cols) {
+    to.check.cols <- paste("comment[",to.check.cols,"]",sep="")
+  }
+  if (factor.cols) {
+    to.check.cols <- paste("factorvalue[",to.check.cols,"]",sep="")
+  }
+  if (characteristic.cols) {
+    to.check.cols <- paste("characteristics[",to.check.cols,"]",sep="")
+  }
+  if ( !comment.cols && ! characteristic.cols && !factor.cols ) {        
+    sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=TRUE)
+    to.check.cols <- normalize.cols(cols,strip.brackets=TRUE)
+  }
+  found <- to.check.cols %in% sdrf.cols
+  
+  if (any(! found) ) {
+    missed_cols <- cols[! found]
+    missing.error <- paste0("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
     
-    if (any(! found) ) {
-      missed_cols <- cols[! found]
-      missing.error <- paste0("SDRF: Column(s) ", paste(missed_cols, collapse=","), " not found")
-
-      if (exit.on.error) {
-            perror(missing.error)
-            q(status=1)
-        }
-        addWarning(missing.error)
+    if (exit.on.error) {
+      perror(missing.error)
+      q(status=1)
     }
-    return(found)
+    addWarning(missing.error)
+  }
+  return(found)
 }
 
 # Get an SDRF column, normalising the supplied field name
@@ -236,7 +236,7 @@ getRunInfo <- function(run, layout){
     # The code needs to be changed if that is not the case.
     
     rr <- system(paste0("cat ",info.file,"|sed -E 's/_L[0-9]+_R[A0-9]+_[0-9]+//'"),intern=TRUE)
-   
+    
     strand <- getSDRFCol('library strand', layout, drop = FALSE)[run,]
     
     if ( grepl("(first|second)",strand ) ) {
@@ -262,10 +262,10 @@ getRunInfo <- function(run, layout){
     
     # Record a technical replicate group
     if ( colsInSDRF(techrep.col, layout) ){
-        techrep.groups <- getSDRFCol(techrep.col, layout, drop = FALSE)
-        tr.numeric.groups <- as.numeric(as.factor(techrep.groups[,1]))
-
-        rr <- c(rr,paste0("",run,"_sample=", tr.numeric.groups[rownames(techrep.groups) == run]))
+      techrep.groups <- getSDRFCol(techrep.col, layout, drop = FALSE)
+      tr.numeric.groups <- as.numeric(as.factor(techrep.groups[,1]))
+      
+      rr <- c(rr,paste0("",run,"_sample=", tr.numeric.groups[rownames(techrep.groups) == run]))
     }
     rr
   }else{
@@ -509,9 +509,9 @@ if ( !is.null(opt$idf_file) ) {
 # single-cell specific things to the checks.
 
 if( is.singlecell ) {
- 
+  
   pinfo("Single cell experiment found")
- 
+  
   sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file", "index2 file","index3 file")
   
   supported.single.cell.protocols <- c("smart-seq2","smarter","smart-like","10xv2","10xv1","drop-seq","10xv1a")
@@ -639,7 +639,7 @@ if ( is.singlecell ) {
   )
   
   row.required.fastq.fields <- sc.required.fastq.fields[match(protocols, tolower(names(sc.required.fastq.fields)))] 
-    
+  
   sc.optional.fastq.fields = list(
     '10xv1' = c('index1 file', 'index2 file'),    
     '10xv1a' = c('index2 file'),         
@@ -650,13 +650,13 @@ if ( is.singlecell ) {
     "smarter" = c(),
     "smart-like" = c()
   )
-
+  
   # Consider any of the optional file fields that occur in the SDRF
   
   row.optional.fastq.fields <- lapply(sc.optional.fastq.fields[match(protocols, tolower(names(sc.optional.fastq.fields)))], function(x) intersect(x, colnames(sdrf))) 
   
 }else{
-
+  
   # For bulk, just check rows for fastq_uri
   
   row.required.fastq.fields <- rep(list('fastq_uri'), nrow(sdrf))
@@ -740,13 +740,10 @@ row.files <- lapply(1:nrow(sdrf), function(row.no){
 
 ## Check that all specified files actually exist
 
-fastq.dir <- file.path(opt$data_dir,"raw_data", opt$raw_dir)
-rows.files.exist <- lapply(row.files, function(x) fastqFileExists(x, fastq.dir, subfolders=split.files.by.subfolders) )
-
-rows.with.missing.files <- which(unlist(lapply(rows.files.exist, function(x) any(! x))))
-
-if (length(rows.with.missing.files) > 0){
-  missing.row.files <- unlist(lapply(rows.with.missing.files, function(x) paste(paste0('Row ', x, ':'), paste(names(row.files[[x]])[ ! rows.files.exist[[x]]], collapse=','))))
+if ( ! opt$check_only ) {
+  
+  fastq.dir <- file.path(opt$data_dir,"raw_data", opt$raw_dir)
+  rows.files.exist <- lapply(row.files, function(x) fastqFileExists(x, fastq.dir, subfolders=split.files.by.subfolders) )
   
   first_missing <- missing.row.files[1:min(length(missing.row.files),10)]
   
@@ -832,7 +829,7 @@ for (species in names(sdrf.by.species)){
     n.techrep.groups <- length(unique(tr))
     
     is.empty <- tr == "" | is.na(tr) | tr == 'NA' | tr == 'not applicable'
-
+    
     if ( (! all(is.empty)) && any(is.empty) ){
       perror("SDRF: Found ",sum(is.empty)," entries in technical replicate group without values where some values are set")
       q(status=1)
@@ -874,7 +871,7 @@ for (species in names(sdrf.by.species)){
       q(status=1)
     }
   }
- 
+  
   species.properties[[species]] <- properties 
 }
 
@@ -915,20 +912,20 @@ configs <- lapply(names(sdrf.by.species), function(species){
   ## Set up for technical replication (or not)
   
   techreps.conf=#technical_replicates="
-  
-  if(properties$has.techrep) {
     
-    # Subset the layout to get samples and replicate groups
-    techreps.runs <- getSDRFCol(c('run', techrep.col), species.layout, order.by = techrep.col)
-    
-    # Group runs/samples by techrep group
-    techreps.by.group <- aggregate( techreps.runs$run, by=list(techrep.group=techreps.runs[,2]), FUN=paste, collapse="," )
-    
-    techrep.run.groups <- paste(unlist(techreps.by.group$x),collapse=";",sep="")
-    techrep.group.labels <- paste(techreps.by.group$techrep.group,collapse=";",sep="")
-    
-    techreps.conf = paste(paste0("technical_replicates=", techrep.run.groups), paste0("technical_replicates_labels=",techrep.group.labels), sep = "\n")  
-  }
+    if(properties$has.techrep) {
+      
+      # Subset the layout to get samples and replicate groups
+      techreps.runs <- getSDRFCol(c('run', techrep.col), species.layout, order.by = techrep.col)
+      
+      # Group runs/samples by techrep group
+      techreps.by.group <- aggregate( techreps.runs$run, by=list(techrep.group=techreps.runs[,2]), FUN=paste, collapse="," )
+      
+      techrep.run.groups <- paste(unlist(techreps.by.group$x),collapse=";",sep="")
+      techrep.group.labels <- paste(techreps.by.group$techrep.group,collapse=";",sep="")
+      
+      techreps.conf = paste(paste0("technical_replicates=", techrep.run.groups), paste0("technical_replicates_labels=",techrep.group.labels), sep = "\n")  
+    }
   
   # SC prototol
   

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -277,6 +277,7 @@ getRunInfo <- function(run, layout){
 # Basic initalisation 
 ################################################################################
 
+cat("\n")
 pinfo(">>> Commencing SDRF validation")
 
 # Do some introspection on arguments
@@ -509,7 +510,6 @@ if ( !is.null(opt$idf_file) ) {
 
 if( is.singlecell ) {
  
-  cat("\n")
   pinfo("Single cell experiment found")
  
   sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file", "index2 file","index3 file")
@@ -1014,12 +1014,6 @@ if ( length(configs)==0 ) {
 }
 
 ## Write final outputs
-
-cat("\n################################################################################\n")
-pinfo('### SDRF checks are done. Summary and warning printed below')
-cat("################################################################################\n")
-
-## We're done parseing the SDRF, print some information on its content
 
 cat("\n")
 pinfo("### SDRF summary info\n")

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -28,12 +28,14 @@ if ( IRAP.DIR == "" ) {
   cat("ERROR: environment variable IRAP_DIR is not set\n")
   q(status=1)
 }
-#
+
 # specify our desired options in a list
-#
+
 source(paste(IRAP.DIR,"aux/R","irap_utils.R",sep="/"))
 pdebug.enabled <- TRUE
+
 #######################
+
 usage <- "irap_sdrf2conf --name exp_name --species species --sdrf file --out_conf  [options]"
 filenames <- c("sdrf_file","idf_file")
 
@@ -61,14 +63,17 @@ option_list <- list(
 multiple.options = list()
 mandatory <- c("sdrf_file","out_conf","name","species")
 
-#pinfo("saved")
 opt <- myParseArgs(usage = usage, option_list=option_list,filenames.exist=filenames,multiple.options=multiple.options,mandatory=mandatory)
 
 pdebug.enabled <- opt$debug
 
-## validates each file independently using fastq_info
+################################################################################
+# Function definitions
+################################################################################
+
 checkFiles <- function(filenames.v,validator.cmd="irap_fastq_info",subfolders=FALSE,opt) {
     ## filenames.v - as provided in the SDRF
+
     addLibSubfolder <- function(f) {
         paste0(system(paste0("get_lib_folder ",f),intern=TRUE),"/",f)
     }
@@ -81,13 +86,13 @@ checkFiles <- function(filenames.v,validator.cmd="irap_fastq_info",subfolders=FA
     filenames.v <- sapply(filenames.v,fixFilename)
     exp.files <- filenames.v
     dir <- paste0(opt$data_dir,"/raw_data")
-    #exp.files.p <- paste(opt$raw_dir,"/",exp.files,sep="")
     exp.files.ps <- paste(exp.files,collapse=" ",sep="")
 
     stopifnot(validator.cmd %in% c("fastq_info","irap_fastq_info"))
     stopifnot(length(filenames.v)>0 && length(filenames.v)<=2)
     use.cached <- FALSE
     info.file <- paste0(dir,"/",opt$raw_dir,"/",exp.files[1],".info")
+    
     if (validator.cmd=="fastq_info" ) {
         ## check if file exists before running fastq_info again
         if ( file.exists(info.file) ) {
@@ -108,10 +113,9 @@ checkFiles <- function(filenames.v,validator.cmd="irap_fastq_info",subfolders=FA
         pinfo("Checking ",exp.files.ps)
         rr <- system(paste0(cmd),intern=FALSE,ignore.stdout=TRUE)
         
-        ##print(rr)
         if ( ! file.exists(info.file) || rr!=0 ) {
             print(cmd)
-        ## rerun command to report the error
+            ## rerun command to report the error
             rr <- system(paste0("pushd ",dir," && ",cmd.err),intern=FALSE,ignore.stdout=TRUE,ignore.stderr=FALSE)        
             perror("Failed to validate and generate info file ",info.file)
             q(status=1)
@@ -146,179 +150,7 @@ normalize.cols <- function(vals,strip.brackets=TRUE) {
     x <- gsub("_+"," ",x) ## no underscores
     return(tolower(gsub(" +"," ",x))) ##lowercase and single space
 }
-#
-pdebug.save.state("irap_sdrf2conf","p0")
-sdfcols2save2tsv <- c()
 
-for ( n in names(opt) ) {
-    cat(paste0(n,"=",opt[[n]]))
-}
-##
-
-pinfo("Loading SDRF ",opt$sdrf_file," ...")
-sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="")
-pinfo("Loading SDRF...done.")
-cat("Columns: ",ncol(sdrf),"\n")
-cat("Entries: ",nrow(sdrf),"\n")
-pinfo("Columns found in SDRF:")
-cat(paste(colnames(sdrf),collapse=","),"\n")
-##print(head(sdrf))
-
-#################################################
-## factors should not be simultaneously comments 
-factors <- normalize.cols(colnames(sdrf)[grepl("^factorvalue",colnames(sdrf),ignore.case=TRUE)])
-comments <- normalize.cols(colnames(sdrf)[grepl("^comment",colnames(sdrf),ignore.case=TRUE)])
-characteristics <- normalize.cols(colnames(sdrf)[grepl("^characteristics",colnames(sdrf),ignore.case=TRUE)])
-
-common <- intersect(factors,comments)
-if (length(common)>0) {
-    if ( opt$atlas_mode==TRUE ) {
-        perror("SDRF: common factors and comments - ",paste(common,collapse=","))
-        q(status=1)
-    }
-    addWarning("SDRF: common factors and comments - ",paste(common,collapse=","))
-}
-## common <- intersect(factors,characteristics)
-## if (length(common)>0) {
-##     if ( opt$atlas_mode==TRUE ) {
-##         perror("SDRF: common factors and characteristics - ",paste(common,collapse=","))
-##         q(status=1)
-##     }
-##     addWarning("SDRF: common factors and characteristics - ",paste(common,collapse=","))
-## }
-common <- intersect(comments,characteristics)
-if (length(common)>0) {
-    if ( opt$atlas_mode==TRUE ) {
-        perror("SDRF: common characteristics and comments - ",paste(common,collapse=","))
-        q(status=1)
-    }
-    addWarning("SDRF: common characteristics and comments - ",paste(common,collapse=","))
-}
-
-##
-idf <- NULL
-if ( !is.null(opt$idf_file) ) {
-    pinfo("Loading IDF...")
-    #idf <- read.tsv(opt$idf_file,header=FALSE,comment.char="",fill=TRUE,blank.lines.skip = TRUE,sep="\t")
-    idf <- read.tsv(opt$idf_file,header=FALSE,comment.char="",fill=TRUE,quote="")
-    if (is.null(idf) ) {
-        perror("Error while loading IDF file ",opt$idf_file)
-        q(status=1)
-    }
-    pinfo("Loading IDF...done.")    
-    ## exclude blank lines
-    idf <- idf[idf$V1!="",,drop=FALSE]
-    cat("Columns: ",ncol(idf),"\n")
-    cat("Entries: ",nrow(idf),"\n")
-    #######################################
-    ## SecondaryAccession may be non-unique
-    if ( sum(tolower(idf[,1])!="comment[secondaryaccession]") > 1 ) {
-        addWarning("IDF: Multiple 'SecondaryAccession' entries")
-    }
-    idf <- idf[tolower(idf[,1])!="comment[secondaryaccession]",]
-    ## basic idf check (non unique rownames)
-    dups <- duplicated(idf[,1])
-    if ( sum(dups) > 0 ) {
-        dupss <- paste(idf[dups,1],sep=",",collapse=",")
-        perror("Duplicated entries: ",dupss)
-        q(status=1)
-    }
-    ## error handling should be improved...
-    rownames(idf) <- tolower(gsub("\\s*\\]\\s*","",gsub("^\\s*COMMENT\\s*\\[\\s*","",as.character(idf[,1]),ignore.case=TRUE)))
-    idf <- idf[,-1,drop=FALSE]
-    ## be tolerant about the EA comments
-    rownames(idf) <- gsub("^ea","",rownames(idf))
-    ## initial check
-    if (! "sdrf file" %in% rownames(idf) ) {
-        perror("SDRF file missing from IDF file")
-        q(status=1)
-    }
-    if ( idf["sdrf file",1]!=basename(opt$sdrf_file) ) {      
-        perror("SDRF file in IDF (",idf["sdrf file",1],") differs from given sdrf file name ",basename(opt$sdrf_file))
-        q(status=1)
-    }
-    cat("IDF:",paste(rownames(idf),collapse=","),"\n")    
-    ##expectedclusters
-    ##
-    ## ExperimentType       differential|baseline (mandatory)
-    ## ExpectedClusters     may be empty
-    ## AdditionalAttributes - characteristics (optional) exist in the SDRF
-    ## AEExperimentType RNA-seq of coding RNA from single cells (single cell)
-    ## Protocol Name should match SDRF
-    ## Experimental Factor Name (mandatory) exist in the SDRF
-    ## note: factors and characteristics should always be lower case!! @Laura
-    expected.in.idf <- c()
-    if ( opt$is_sc ) {
-        expected.in.idf <- c("expectedclusters")
-        names(expected.in.idf) <- c("EAExpectedClusters")
-    }
-    if ( opt$atlas_mode ) {
-        expected.in.idf2 <- c("experimenttype","experimental factor name","protocol name")
-        names(expected.in.idf2) <- c("AEExperimentType","Experimental Factor Name","Protocol Name")
-        expected.in.idf <- c(expected.in.idf,expected.in.idf2)
-    }
-    not.present <- (!expected.in.idf%in%rownames(idf))
-    if ( sum(not.present)>0 ) {
-        perror("IDF incomplete. Missing ",paste(names(expected.in.idf)[not.present],sep=",",collapse=","))
-        q(status=1)
-    }
-    if ( opt$atlas_mode ) {
-        if ( sum(c("baseline","differential") %in% tolower(idf["experimenttype",1]))==0 ) {
-            perror("IDF error in EAExperimentType: Invalid value (",idf["experimenttype",1],") expected baseline or differential")
-            q(status=1)
-        }
-        ##AEExperimentType
-        expected.vals <- tolower(c("RNA-seq of coding RNA from single cells","RNA-seq of coding RNA"))
-        if ( sum( expected.vals %in% tolower(idf["aeexperimenttype",1]))==0 ) {
-            perror("IDF error in AEExperimentType: Invalid value (",idf["aeexperimenttype",1],") expected ",paste(expected.vals,sep=" or ",collapse=" or "))
-            q(status=1)
-        }
-        if ( expected.vals[1] %in% tolower(idf["aeexperimenttype",1]) ) {
-            opt$is_sc <- TRUE
-        }
-    }
-}
-
-if (opt$is_sc) {
-    pinfo("Single cell experiment")
-} 
-#################################
-## Check mandactory columns (SDRF)
-exp.cols <- c("Source Name")
-
-exp.comment.cols <- c("LIBRARY_STRATEGY","LIBRARY_SOURCE","LIBRARY_SELECTION","LIBRARY_LAYOUT","FASTQ_URI")
-
-## 
-exp.characteristic.cols <- c()
-exp.factor.cols <- c()
-opt.cols <- c("ORGANISM","organism part","sex","spike in","molecule","technical replicate group","ENA_RUN","ENA_SAMPLE","Scan Name")
-
-sc.exp.cols <- c("Material Type","library_construction","single cell isolation")
-sc.exp.comment.cols <- c("LIBRARY_STRAND")
-
-##
-#sc.exp.factor.cols <- c("single cell identifier")
-sc.exp.factor.cols <- c()
-sc.exp.characteristic.cols <- c()
-sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file")
-
-#optional.cols <- c("")
-
-expected.cols <- exp.cols
-expected.comment.cols <- exp.comment.cols
-expected.factor.cols <- exp.factor.cols
-expected.characteristic.cols <- exp.characteristic.cols
-#opt.cols <- 
-if( opt$is_sc ) {
-    expected.cols <- append(expected.cols,sc.exp.cols)
-    expected.comment.cols <- append(exp.comment.cols,sc.exp.comment.cols)
-    expected.characteristic.cols <- append(exp.characteristic.cols,sc.exp.characteristic.cols)
-    expected.factor.cols <- append(exp.factor.cols,sc.exp.factor.cols)
-    opt.cols <- append(opt.cols,sc.opt.cols)
-}
-
-#"Characteristics[developmental stage]"           
-#"Characteristics [cell type]"               
 colsInSDRF <- function(cols,sdrf,comment.cols=FALSE,characteristic.cols=FALSE,factor.cols=FALSE,exit.on.error=TRUE) {
     if ( length(cols) == 0 ) return
     sdrf.cols <- normalize.cols(colnames(sdrf),strip.brackets=FALSE)
@@ -347,6 +179,178 @@ colsInSDRF <- function(cols,sdrf,comment.cols=FALSE,characteristic.cols=FALSE,fa
     }
 }
 
+################################################################################
+# Main script body
+################################################################################
+
+pdebug.save.state("irap_sdrf2conf","p0")
+sdfcols2save2tsv <- c()
+
+for ( n in names(opt) ) {
+    cat(paste0(n,"=",opt[[n]]))
+}
+
+pinfo("Loading SDRF ",opt$sdrf_file," ...")
+sdrf <- read.tsv(opt$sdrf_file,header=TRUE,comment.char="")
+pinfo("Loading SDRF...done.")
+cat("Columns: ",ncol(sdrf),"\n")
+cat("Entries: ",nrow(sdrf),"\n")
+pinfo("Columns found in SDRF:")
+cat(paste(colnames(sdrf),collapse=","),"\n")
+
+## Factors should not be simultaneously comments 
+
+factors <- normalize.cols(colnames(sdrf)[grepl("^factorvalue",colnames(sdrf),ignore.case=TRUE)])
+comments <- normalize.cols(colnames(sdrf)[grepl("^comment",colnames(sdrf),ignore.case=TRUE)])
+characteristics <- normalize.cols(colnames(sdrf)[grepl("^characteristics",colnames(sdrf),ignore.case=TRUE)])
+
+common <- intersect(factors,comments)
+if (length(common)>0) {
+    if ( opt$atlas_mode==TRUE ) {
+        perror("SDRF: common factors and comments - ",paste(common,collapse=","))
+        q(status=1)
+    }
+    addWarning("SDRF: common factors and comments - ",paste(common,collapse=","))
+}
+
+common <- intersect(comments,characteristics)
+if (length(common)>0) {
+    if ( opt$atlas_mode==TRUE ) {
+        perror("SDRF: common characteristics and comments - ",paste(common,collapse=","))
+        q(status=1)
+    }
+    addWarning("SDRF: common characteristics and comments - ",paste(common,collapse=","))
+}
+
+## Load and check the IDF where provided
+
+idf <- NULL
+if ( !is.null(opt$idf_file) ) {
+    pinfo("Loading IDF...")
+    idf <- read.tsv(opt$idf_file,header=FALSE,comment.char="",fill=TRUE,quote="")
+    if (is.null(idf) ) {
+        perror("Error while loading IDF file ",opt$idf_file)
+        q(status=1)
+    }
+    pinfo("Loading IDF...done.")    
+    ## exclude blank lines
+    idf <- idf[idf$V1!="",,drop=FALSE]
+    cat("Columns: ",ncol(idf),"\n")
+    cat("Entries: ",nrow(idf),"\n")
+
+    ## SecondaryAccession may be non-unique
+    if ( sum(tolower(idf[,1])!="comment[secondaryaccession]") > 1 ) {
+        addWarning("IDF: Multiple 'SecondaryAccession' entries")
+    }
+
+    idf <- idf[tolower(idf[,1])!="comment[secondaryaccession]",]
+    
+    ## basic idf check (non unique rownames)
+    dups <- duplicated(idf[,1])
+    if ( sum(dups) > 0 ) {
+        dupss <- paste(idf[dups,1],sep=",",collapse=",")
+        perror("Duplicated entries: ",dupss)
+        q(status=1)
+    }
+  
+    ## error handling should be improved...
+    rownames(idf) <- tolower(gsub("\\s*\\]\\s*","",gsub("^\\s*COMMENT\\s*\\[\\s*","",as.character(idf[,1]),ignore.case=TRUE)))
+    idf <- idf[,-1,drop=FALSE]
+
+    ## be tolerant about the EA comments
+    rownames(idf) <- gsub("^ea","",rownames(idf))
+
+    ## initial check
+    if (! "sdrf file" %in% rownames(idf) ) {
+        perror("SDRF file missing from IDF file")
+        q(status=1)
+    }
+    if ( idf["sdrf file",1]!=basename(opt$sdrf_file) ) {      
+        perror("SDRF file in IDF (",idf["sdrf file",1],") differs from given sdrf file name ",basename(opt$sdrf_file))
+        q(status=1)
+    }
+    cat("IDF:",paste(rownames(idf),collapse=","),"\n")    
+
+    ##expectedclusters
+    ##
+    ## ExperimentType       differential|baseline (mandatory)
+    ## ExpectedClusters     may be empty
+    ## AdditionalAttributes - characteristics (optional) exist in the SDRF
+    ## AEExperimentType RNA-seq of coding RNA from single cells (single cell)
+    ## Protocol Name should match SDRF
+    ## Experimental Factor Name (mandatory) exist in the SDRF
+    ## note: factors and characteristics should always be lower case!! @Laura
+
+    expected.in.idf <- c()
+    if ( opt$is_sc ) {
+        expected.in.idf <- c("expectedclusters")
+        names(expected.in.idf) <- c("EAExpectedClusters")
+    }
+
+    if ( opt$atlas_mode ) {
+        expected.in.idf2 <- c("experimenttype","experimental factor name","protocol name")
+        names(expected.in.idf2) <- c("AEExperimentType","Experimental Factor Name","Protocol Name")
+        expected.in.idf <- c(expected.in.idf,expected.in.idf2)
+    }
+
+    not.present <- (!expected.in.idf%in%rownames(idf))
+    if ( sum(not.present)>0 ) {
+        perror("IDF incomplete. Missing ",paste(names(expected.in.idf)[not.present],sep=",",collapse=","))
+        q(status=1)
+    }
+
+    if ( opt$atlas_mode ) {
+        if ( sum(c("baseline","differential") %in% tolower(idf["experimenttype",1]))==0 ) {
+            perror("IDF error in EAExperimentType: Invalid value (",idf["experimenttype",1],") expected baseline or differential")
+            q(status=1)
+        }
+
+        ##AEExperimentType
+        expected.vals <- tolower(c("RNA-seq of coding RNA from single cells","RNA-seq of coding RNA"))
+        if ( sum( expected.vals %in% tolower(idf["aeexperimenttype",1]))==0 ) {
+            perror("IDF error in AEExperimentType: Invalid value (",idf["aeexperimenttype",1],") expected ",paste(expected.vals,sep=" or ",collapse=" or "))
+            q(status=1)
+        }
+
+        if ( expected.vals[1] %in% tolower(idf["aeexperimenttype",1]) ) {
+            opt$is_sc <- TRUE
+        }
+    }
+}
+
+if (opt$is_sc) {
+    pinfo("Single cell experiment")
+} 
+
+## Check mandactory columns (SDRF)
+
+exp.comment.cols <- c("LIBRARY_STRATEGY","LIBRARY_SOURCE","LIBRARY_SELECTION","LIBRARY_LAYOUT","FASTQ_URI")
+exp.characteristic.cols <- c()
+exp.factor.cols <- c()
+
+opt.cols <- c("ORGANISM","organism part","sex","spike in","molecule","technical replicate group","ENA_RUN","ENA_SAMPLE","Scan Name")
+
+expected.cols <- exp.cols
+expected.comment.cols <- exp.comment.cols
+expected.factor.cols <- exp.factor.cols
+expected.characteristic.cols <- exp.characteristic.cols
+
+## Single-cell specific
+
+sc.exp.cols <- c("Material Type","library_construction","single cell isolation")
+sc.exp.comment.cols <- c("LIBRARY_STRAND")
+sc.exp.factor.cols <- c()
+sc.exp.characteristic.cols <- c()
+sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file")
+
+if( opt$is_sc ) {
+    expected.cols <- append(expected.cols,sc.exp.cols)
+    expected.comment.cols <- append(exp.comment.cols,sc.exp.comment.cols)
+    expected.characteristic.cols <- append(exp.characteristic.cols,sc.exp.characteristic.cols)
+    expected.factor.cols <- append(exp.factor.cols,sc.exp.factor.cols)
+    opt.cols <- append(opt.cols,sc.opt.cols)
+}
+
 pinfo("Checking presence of columns...")
 colsInSDRF(expected.cols,sdrf)
 colsInSDRF(expected.characteristic.cols,sdrf,characteristic.cols=TRUE)
@@ -370,7 +374,6 @@ for (col in tolower(c(expected.cols,expected.comment.cols,expected.factor.cols,e
         pinfo(col,": single value per row")
     } else {
         pinfo(col,": ",length(tt)," unique values")
-        ##pinfo(col,": ");print(head(sort(tt,decreasing=TRUE),n=10))
     }
 }
 #######################

--- a/scripts/irap_sdrf2conf
+++ b/scripts/irap_sdrf2conf
@@ -23,7 +23,6 @@
 ################################################################################
 # Initialisation
 ################################################################################
-
 suppressPackageStartupMessages(library("optparse"))
 
 IRAP.DIR <- Sys.getenv(c("IRAP_DIR"))
@@ -69,12 +68,6 @@ mandatory <- c("sdrf_file","out_conf","name","species", "species_conf", "idf_fil
 
 opt <- myParseArgs(usage = usage, option_list=option_list,filenames.exist=filenames,multiple.options=list(),mandatory=mandatory)
 
-# Do some introspection on arguments
-
-for ( n in names(opt) ) {
-  cat(paste0(n,"=",opt[[n]]))
-}
-
 pdebug.enabled <- opt$debug
 
 ################################################################################
@@ -92,7 +85,7 @@ addWarning <- function(...) {
 printAllWarnings <- function() {
     n <- length(warnings.lst)
     if ( n > 0 ) return
-    pinfo('### ', n," warnings. Unique entries:")
+    pinfo(n," warnings. Unique entries:")
     prints <- sapply(unique(warnings.lst),pwarning)
 }
 
@@ -215,7 +208,7 @@ fastqFileExists <- function(filenames, topdir, subfolders = F){
 # Check if a method is a droplet protocol
 
 is.droplet.protocol <- function(x){
-  opt$is_sc && tolower(x) %in% tolower(sc.droplet.protocols)
+  is.singlecell && tolower(x) %in% tolower(sc.droplet.protocols)
 }
 
 # Get the contents of a .info file for a run, if available
@@ -281,12 +274,29 @@ getRunInfo <- function(run, layout){
 }
 
 ################################################################################
-# First round SDRF field checks: before we know about field content 
+# Basic initalisation 
 ################################################################################
 
-if (opt$is_sc) {
-    print.info("Single cell experiment")
-} 
+pinfo(">>> Commencing SDRF validation")
+
+# Do some introspection on arguments
+
+print.info("### Argument values")
+
+for ( n in names(opt) ) {
+  print.info(paste0(n,"=",opt[[n]]))
+}
+
+# Set some variable names we'll be using a lot
+
+techrep.col <- 'technical replicate group'
+sc.identifier.col <- 'single cell identifier'
+sc.protocol.col <- 'library construction'
+is.singlecell <- FALSE
+
+################################################################################
+# First round SDRF field checks: before we know about field content 
+################################################################################
 
 # Load the SDRF
 
@@ -328,40 +338,6 @@ expected.characteristic.cols <- c()
 expected.factor.cols <- c()
 opt.cols <- c("ORGANISM","organism part","sex","spike in","molecule","technical replicate group","ENA_RUN","ENA_SAMPLE","Scan Name")
 layout.cols <- c("run", "library_layout", "ena_sample", "library_layout", "library_strand", "technical replicate group")
-
-# Single-cell specific.
-
-if( opt$is_sc ) {
-  
-  sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file", "index2 file","index3 file")
-  
-  supported.single.cell.protocols <- c("smart-seq2","smarter","smart-like","10xv2","10xv1","drop-seq","10xv1a")
-  sc.droplet.protocols <- c('10xv1', '10xv1a', '10xv1i', '10xv2', 'drop-seq')
-  
-  expected.cols <- append(expected.cols, c("Material Type","library_construction","single cell isolation"))
-  expected.comment.cols <- append(expected.comment.cols, c("LIBRARY_STRAND"))
-  opt.cols <- append(opt.cols,sc.opt.cols)
-}
-
-print.info("Checking presence of columns...")
-
-found <- colsInSDRF(expected.cols, sdrf, exit.on.error = TRUE)
-found <- colsInSDRF(expected.characteristic.cols,sdrf,characteristic.cols=TRUE, exit.on.error = TRUE)
-found <- colsInSDRF(expected.comment.cols,sdrf,comment.cols=TRUE, exit.on.error = TRUE)
-found <- colsInSDRF(expected.factor.cols,sdrf,factor.cols=TRUE, exit.on.error = TRUE)
-
-print.info("Checking the presence of columns... done.")
-
-# Set some variable names we'll be using a lot
-
-techrep.col <- 'technical replicate group'
-sc.identifier.col <- 'single cell identifier'
-sc.protocol.col <- 'library construction'
-
-# Now we've checked comments etc we can forget what sort of field these are and
-# regularise the column names
-
-colnames(sdrf) <- normalize.cols(tolower(colnames(sdrf)))
 
 ################################################################################
 # Load and check the IDF where provided, and cross-reference with the SDRF
@@ -437,7 +413,7 @@ if ( !is.null(opt$idf_file) ) {
   
   # Required fields for single-cell
   
-  if ( opt$is_sc ) {
+  if ( is.singlecell ) {
     expected.in.idf <- c("expectedclusters")
     names(expected.in.idf) <- c("EAExpectedClusters")
   }
@@ -479,7 +455,7 @@ if ( !is.null(opt$idf_file) ) {
     
     # Override argument if we find single-cell experiment type
     
-    opt$is_sc <- names(valid.exp.types)[tolower(valid.exp.types) == exp.type] == 'single_cell'
+    is.singlecell <- names(valid.exp.types)[tolower(valid.exp.types) == exp.type] == 'single_cell'
     
     ## - Experimental Factor Name (mandatory) exist in the SDRF
     
@@ -519,7 +495,7 @@ if ( !is.null(opt$idf_file) ) {
     idf.attrs <- sapply(attrs[attrs!=""],tolower)
     
     # Check for fields absent in the SDRF
-    not.present <- (! idf.attrs %in% colnames(sdrf))
+    not.present <- (! idf.attrs %in% normalize.cols(colnames(sdrf)))
     
     if (sum(not.present)) {
       perror("IDF error in EAAdditionalAttributes:",paste(idf.attrs[not.present],sep=",")," not found in SDRF")
@@ -527,6 +503,40 @@ if ( !is.null(opt$idf_file) ) {
     }
   }
 }
+
+# Having derived possible single-cell status from the IDF we can add
+# single-cell specific things to the checks.
+
+if( is.singlecell ) {
+ 
+  cat("\n")
+  pinfo("Single cell experiment found")
+ 
+  sc.opt.cols <- c("single cell quality","input molecule","end bias","single cell library method","read1 file","read2 file","index1 file", "index2 file","index3 file")
+  
+  supported.single.cell.protocols <- c("smart-seq2","smarter","smart-like","10xv2","10xv1","drop-seq","10xv1a")
+  sc.droplet.protocols <- c('10xv1', '10xv1a', '10xv1i', '10xv2', 'drop-seq')
+  
+  expected.cols <- append(expected.cols, c("Material Type","library_construction","single cell isolation"))
+  expected.comment.cols <- append(expected.comment.cols, c("LIBRARY_STRAND"))
+  opt.cols <- append(opt.cols,sc.opt.cols)
+}
+
+# Now do the checks
+
+print.info("Checking presence of columns...")
+
+found <- colsInSDRF(expected.cols, sdrf, exit.on.error = TRUE)
+found <- colsInSDRF(expected.characteristic.cols,sdrf,characteristic.cols=TRUE, exit.on.error = TRUE)
+found <- colsInSDRF(expected.comment.cols,sdrf,comment.cols=TRUE, exit.on.error = TRUE)
+found <- colsInSDRF(expected.factor.cols,sdrf,factor.cols=TRUE, exit.on.error = TRUE)
+
+print.info("Checking the presence of columns... done.")
+
+# Now we've checked comments etc we can forget what sort of field these are and
+# regularise the column names
+
+colnames(sdrf) <- normalize.cols(tolower(colnames(sdrf)))
 
 ################################################################################
 # Further SDRF checks now we know the right fields are there and we can look at
@@ -550,7 +560,7 @@ print.info("Species: ",paste(unique(sdrf$organism)),"\n")
 ## SDRF-wide single-cell checks. This can result in filtering out rows, so do it
 ## early. In the process we also work out what fastq files are required
 
-if ( opt$is_sc ) {
+if ( is.singlecell ) {
   
   ## single cell quality
   
@@ -834,7 +844,7 @@ for (species in names(sdrf.by.species)){
       # technical replication. But since droplet protocols have multiple cells per
       # run we'll give these entries the benefit of the doubt.
       
-      if (opt$is_sc && all(is.droplet.protocol(unique(getSDRFCol('library construction', species.sdrf))))){
+      if (is.singlecell && all(is.droplet.protocol(unique(getSDRFCol('library construction', species.sdrf))))){
         properties$has.techrep <- TRUE
       }
     }else{
@@ -854,7 +864,7 @@ for (species in names(sdrf.by.species)){
     }
   }
   
-  if (opt$is_sc){
+  if (is.singlecell){
     
     # Need a single protocol
     
@@ -870,9 +880,11 @@ for (species in names(sdrf.by.species)){
 
 # With all checks done, we can stop if no further output is required
 
+pinfo("SDRF/IDF looks OK!")    
+
 if ( opt$check_only ) {
   printAllWarnings()
-  pinfo("SDRF/IDF looks OK!")    
+  pinfo("<<< All done: SDRF validation complete, exiting before config creation")
   q(status=0)
 }
 
@@ -923,7 +935,7 @@ configs <- lapply(names(sdrf.by.species), function(species){
   sc.prot.conf = c()
   sc.clusters.conf = c()
   
-  if (opt$is_sc){
+  if (is.singlecell){
     sc.prot.conf = paste0("sc_protocol=", getSDRFCol(sc.protocol.col, species.sdrf)[1])
     
     ## Decide what range of K values to try. Use a window around the provided
@@ -1003,14 +1015,14 @@ if ( length(configs)==0 ) {
 
 ## Write final outputs
 
-cat("\n\n")
+cat("\n################################################################################\n")
 pinfo('### SDRF checks are done. Summary and warning printed below')
-cat("\n")
+cat("################################################################################\n")
 
 ## We're done parseing the SDRF, print some information on its content
 
 cat("\n")
-pinfo("### Printing SDRF summary info")
+pinfo("### SDRF summary info\n")
 cat("Columns: ",ncol(sdrf),"\n")
 cat("Entries: ",nrow(sdrf),"\n")
 pinfo("Columns found in SDRF:")
@@ -1030,10 +1042,11 @@ for (col in tolower(c(expected.cols,expected.comment.cols,expected.factor.cols,e
 }
 
 cat("\n")
+pinfo("### Warnings\n")
 printAllWarnings()
 
 cat("\n")
-pinfo("### Outputs:")
+pinfo("### Outputs\n")
 
 for (species in names(configs)){
   
@@ -1063,5 +1076,5 @@ for (species in names(configs)){
 }
 
 cat("\n")
-pinfo("All done")
+pinfo("<<< All done: SDRF validation complete")
 q(status=0)


### PR DESCRIPTION
Note the WIP- I'm still testing, just wanted you to be aware of the work. I expect this might be something of a conversation ;-).

I needed to get a handle on the detail of how the preprocessing stages for SC work, and I found the logical a little difficult. e.g.:

- There's irap_AE_setup.sh, which does some checking of the SDRF, downloads FASTQ files, does a bit of IDF parsing, and passes off to irap_sdrf2conf for some more config checking. It then does some sed magic and substitutes the result of  irap_sdrf2conf. 
- sdrf2conf then does config checks which overlap with those in irap_AE_setup.sh  and then sequential runs of irap_fastq_info which takes a very long time for large run numbers. The logic of this script is also a little difficult to understand and interpret.

This PR proposes the following large-scale simplifications:

- SDRF and IDF checks to be done entirely by irap_sdrf2conf.
- irap_sdrf2conf to read IDF directly (this functionality seemed to be mostly there but unused- I just fixed it up). irap_fastq_info to be removed from this script and moved to irap_AE_setup.sh. To be parallelised in future. 
- Eliminate sed-based editing of config file by passing the necessary info directly to irap_sdrf2conf
- irap_AE_setup.sh to be limited to download and irap_fastq_info checks of FASTQ files, everything else passed off to  irap_sdrf2conf.

I've also done a fair bit of cleaning up and bug-fixing. Changes include:

⁃ Detailed comments to make logic more obvious
- Allow for ‘Factor value’ as well as ‘FactorValue’
⁃ IDF: Fixed check for multiple 'SecondaryAccession' entries
⁃ Allow multiple SequenceDataURI entries
⁃ Don’t look for smartseq etc in the isolation column
⁃ Looks like droplet runs were supposed to be removed from pe and added to se, but there a missing negation - fixed
⁃ Rely on library_construction as protocol method
⁃ Pass organism conf file directly to sdrf2conf, rather than doing all the sed magic in irap_AE_setup.sh

I've tried to make the logic on handling droplet protocols more obvious and have chatted with curators e.g. about what files to expect for the various droplet protocols. Some bit are a bit unclear though - e.g. what's expected for '10xv1' (rather than '10xv1a', which we're fairly clear on). 

As I say- expecting some back-and-forth ;-)